### PR TITLE
Fix display of hidden fields in tabular inline

### DIFF
--- a/grappelli/templates/admin/edit_inline/tabular.html
+++ b/grappelli/templates/admin/edit_inline/tabular.html
@@ -34,7 +34,7 @@
                 {% for fieldset in inline_admin_form %}
                     {% for line in fieldset %}
                         {% for field in line %}
-                            {% if field.is_hidden %} {{ field.field }} {% endif %}
+                            {% if field.field.is_hidden %} {{ field.field }} {% endif %}
                         {% endfor %}
                     {% endfor %}
                 {% endfor %}
@@ -43,15 +43,17 @@
                     {% for fieldset in inline_admin_form %}
                         {% for line in fieldset %}
                             {% for field in line %}
-                                <div class="td {{ field.field.name }} {% if field.field.errors %} error{% endif %}">
-                                    {% if field.is_readonly %}
-                                        <p>{{ field.contents }}</p>
-                                    {% else %}
-                                        {{ field.field }}
-                                        {{ field.field.errors.as_ul }}
-                                    {% endif %}
-                                    {% if field.field.help_text %}<p class="help">{{ field.field.help_text }}</p>{% endif %}
-                                </div>
+                                {% if not field.field.is_hidden %}
+                                    <div class="td {{ field.field.name }} {% if field.field.errors %} error{% endif %}">
+                                        {% if field.is_readonly %}
+                                            <p>{{ field.contents }}</p>
+                                        {% else %}
+                                            {{ field.field }}
+                                            {{ field.field.errors.as_ul }}
+                                        {% endif %}
+                                        {% if field.field.help_text %}<p class="help">{{ field.field.help_text }}</p>{% endif %}
+                                    </div>
+                                {% endif %}
                             {% endfor %}
                         {% endfor %}
                     {% endfor %}


### PR DESCRIPTION
Hidden fields were not correctly output at the top of the inline. Additionally,
hidden fields were displayed as seemingly empty columns and column headers
did not align with their columns. This commit fixes the field output and
completely disables the column output for hidden fields.
