### PR TITLE
wrong path to base_site.html in missing_docutils.html

### DIFF
--- a/grappelli/templates/admin_doc/missing_docutils.html
+++ b/grappelli/templates/admin_doc/missing_docutils.html
@@ -1,4 +1,4 @@
-{% extends "admin/_grappelli/base_site.html" %}
+{% extends "admin/base_site.html" %}
 {% load adminmedia %}
 {% load i18n %}
 {% block bodyclass %}documentation{% endblock %}


### PR DESCRIPTION
Just a small bugfix to have missing_docutils.html render correctly
