### PR TITLE
Fixed jQuery integration in german datepicker.

### DIFF
--- a/grappelli/static/grappelli/jquery/i18n/ui.datepicker-de.js
+++ b/grappelli/static/grappelli/jquery/i18n/ui.datepicker-de.js
@@ -1,6 +1,6 @@
 ﻿/* German initialisation for the jQuery UI date picker plugin. */
 /* Written by Milian Wolff (mail@milianw.de). */
-jQuery(function($){
+(function($){
 	$.datepicker.regional['de'] = {
 		closeText: 'schließen',
 		prevText: '&#x3c;zurück',
@@ -16,5 +16,5 @@ jQuery(function($){
 		dateFormat: 'yy-mm-dd', firstDay: 1,
 		isRTL: false};
 	$.datepicker.setDefaults($.datepicker.regional['de']);
-});
+})(django.jQuery);
 


### PR DESCRIPTION
The german datepicker was not correctly initialized with django.jQuery.
