### PR TITLE
Update documentation to warn against using tuples. Also, fix a typo.

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -156,9 +156,7 @@ Autocomplete Lookups
 
 Add the staticmethod ``autocomplete_search_fields`` to all models you want to search for::
 
-    class     @staticmethod
-    def autocomplete_search_fields():
-       return ("id__iexact", "name__icontains",)(models.Model):
+    class MyModel(models.Model):
         name = models.CharField(u"Name", max_length=50)
     
         @staticmethod
@@ -221,6 +219,9 @@ For the represantation of an object, we first check for a callable ``related_lab
 
 .. warning::
     Due to a bug in Django 1.3, raw_id_fields (including autocomplete-lookups) are not working with list_editables.
+
+.. warning::
+    When defining ``autocomplete_lookup_fields`` and ``related_lookup_fields``, you must use Python list objects instead of tuples.
 
 Using TinyMCE
 -------------


### PR DESCRIPTION
This fixes a typo, as well as includes a warning against using tuples for the `related_lookup_fields` and `autocomplete_lookup_fields`. This warning is the result of a bug I wrestled with for a while today. Here's an example of how to replicate it:

```
autocomplete_lookup_fields = {
    'generic': (('content_type', 'object_id'),)
}
```

The above is output to the template for parsing via javascript as:

```
var autocomplete_fields_generic = [('content_type', 'object_id')];
```

When the expected output is:

```
var autocomplete_fields_generic = [['content_type', 'object_id']];
```
