### PR TITLE
Compatibility issue with python 2.5.*

### DIFF
--- a/grappelli/templatetags/grp_tags.py
+++ b/grappelli/templatetags/grp_tags.py
@@ -2,8 +2,14 @@
 
 # python imports
 from functools import wraps
-import json
+
 import re
+
+# try to use json (2.6+) but stay compatible with 2.5.*
+try:
+    import json
+except ImportError:
+    from django.utils import simplejson as json
 
 # django imports
 from django import template


### PR DESCRIPTION
I had problem deploying a project on my hosting server today.. after some digging I font the offending line in grappelli's grp_tags:

```
import json
```

Problem is that it became a standard library only as python 2.6.  So every sites using python 2.5 will break when updating grappelli.

My commit tries to import json but falls back to the simplejson shipped with django if it cannot import it.

While I understand that python is moving forward and 2.5 will be deprecated, suddenly dropping support when 3 lines of codes are required to make it compatible is a bit drastic. 

Cheers
