### PR TITLE
Tiny tweak to jQuery selector in tabular inline template for sortable_field_name

### DIFF
--- a/grappelli/templates/admin/edit_inline/tabular.html
+++ b/grappelli/templates/admin/edit_inline/tabular.html
@@ -262,7 +262,7 @@
             var sortable_field_name = "{{ inline_admin_formset.opts.sortable_field_name }}";
             var i = 0;
             $("#{{ inline_admin_formset.formset.prefix }}-group").find("div.grp-tbody.grp-dynamic-form").each(function(){
-                var fields = $(this).find("div.td :input[value]");
+                var fields = $(this).find("div.grp-td :input[value]");
                 if (fields.serialize()) {
                     $(this).find("input[name$='"+sortable_field_name+"']").val(i);
                     i++;


### PR DESCRIPTION
Hello there,

I noticed the on-submit JavaScript was not changing the position values for sortable_field_name with tabular admin inlines.

It seems that the jQuery selector needs to be updated to match the grp- class naming convention elsewhere in the template.

Best wishes,
richbs
