### PR TITLE
Add new inlines to DOM after __prefix__ has been substituted with numbers, not earlier

### DIFF
--- a/grappelli/static/grappelli/js/jquery.grp_inline.js
+++ b/grappelli/static/grappelli/js/jquery.grp_inline.js
@@ -102,12 +102,19 @@
             var index = parseInt(totalForms.val(), 10),
                 form = empty_template.clone(true);
             form.removeClass(options.emptyCssClass)
-                .attr("id", empty_template.attr('id').replace("-empty", index))
-                .insertBefore(empty_template)
-                .addClass(options.formCssClass);
-            // update form index
+                .attr("id", empty_template.attr('id').replace("-empty", index));
+
+            // update form index now
             var re = /__prefix__/g;
             updateFormIndex(form, options, re, index);
+
+            // after "__prefix__" strings has been substituted with the number
+            // of the inline, we can add the form to DOM, not earlier.
+            // This way we can support handlers that track live element
+            // adding/removing, like those used in django-autocomplete-light
+            form.insertBefore(empty_template)
+                .addClass(options.formCssClass);
+
             // update total forms
             totalForms.val(index + 1);
             // hide add button in case we've hit the max, except we want to add infinitely


### PR DESCRIPTION
Hi,

I fixed a bug that appeared when I was using django-grappelli with django-autocomplete-light.

Note: original django's admin works OK for this django-autocomplete-light, so you can treat this patch as something that makes django-grappelli internals behave more original django-like.

Bug description: https://github.com/yourlabs/django-autocomplete-light/issues/52 -- and more verbose description how to reproduce it here: http://pokazywarka.pl/3b0wnr/ (assumes that we're running test_grappelli demo from django-autocomplete-light project). 

Reason? Well, original django-admin works with this handler https://github.com/yourlabs/django-autocomplete-light/blob/master/autocomplete_light/static/autocomplete_light/widget.js#L247 in django-autocomplete-light. When django-admin adds elements to DOM, they already have __prefix__ substituted with a number. So, django-autocomplete-light .live handlers catch this up and work properly. 

With django-grappelli, the case was different. As you can see from my patch, the added DOM elements had __prefix__ elements not yet updated; they were updated AFTER the document was changed. So, this way, django-autocomplete-light's javascript didn't catch up with those changes. 

After my patch it works pretty good for me. 
