### PR TITLE
Sort the list of models by title in dashboard.modules.ModelList

### DIFF
--- a/grappelli/dashboard/modules.py
+++ b/grappelli/dashboard/modules.py
@@ -284,6 +284,7 @@ class ModelList(DashboardModule, AppListElementMixin):
             if perms['add']:
                 model_dict['add_url'] = self._get_admin_add_url(model, context)
             self.children.append(model_dict)
+        self.children.sort(key=lambda x: x['title'])
         self._initialized = True
 
 


### PR DESCRIPTION
dashboard.modules.ModelList didn't sort the models, which caused them to randomly shift around every time the user reloads the Django admin page in his browser. I think that's a bit confusing :) I changed the code to sort them by title.
