### PR TITLE
Updated url template tags to support Django 1.5

### DIFF
--- a/grappelli/templates/admin/includes_grappelli/header.html
+++ b/grappelli/templates/admin/includes_grappelli/header.html
@@ -9,7 +9,7 @@
                 <a href="javascript://" class="user-options-handler grp-collapse-handler">{% firstof user.first_name user.username %}</a>
                 <ul class="grp-user-options">
                     <!-- Change Password -->
-                    {% url admin:password_change as password_change_url %}
+                    {% url 'admin:password_change' as password_change_url %}
                     {% if password_change_url %}
                         <li><a href="{{ password_change_url }}">
                     {% else %}
@@ -17,7 +17,7 @@
                     {% endif %}
                     {% trans 'Change password' %}</a></li>
                     <!-- Logout -->
-                    {% url admin:logout as logout_url %}
+                    {% url 'admin:logout' as logout_url %}
                     {% if logout_url %}
                         <li><a href="{{ logout_url }}">
                     {% else %}
@@ -29,12 +29,12 @@
             <!-- Userlinks -->
             {% block userlinks %}
                 <!-- JS tests -->
-                {% url test-index as testindexurl %}
+                {% url 'test-index' as testindexurl %}
                 {% if testindexurl %}
                     <li><a href="{{ testindexurl }}">{% trans 'Tests' %}</a></li>
                 {% endif %}
                 <!-- Documentation -->
-                {% url django-admindocs-docroot as docsroot %}
+                {% url 'django-admindocs-docroot' as docsroot %}
                 {% if docsroot %}
                     <li><a href="{{ docsroot }}">{% trans 'Documentation' %}</a></li>
                 {% endif %}


### PR DESCRIPTION
[Django 1.5](https://docs.djangoproject.com/en/dev/internals/deprecation/#id2) requires the first argument of the url template tag to be a template variable not an implied string. 
