### PR TITLE
Updated path to tiny_mce.js in docs/customization.rst

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -264,7 +264,7 @@ Using TinyMCE
 
     class Media:
         js = [
-            '/static/admin/tinymce/jscripts/tiny_mce/tiny_mce.js',
+            '/static/grappelli/tinymce/jscripts/tiny_mce/tiny_mce.js',
             '/static/path/to/your/tinymce_setup.js',
         ]
 


### PR DESCRIPTION
Hi,

I fixed a minor bug in the section _Using Tiny MCE_ of `docs/customization.rst`. I changed the path for the correct one, where we can find the file `tiny_mce.js`.
