### PR TITLE
set correct case-sensitive dependency for Django in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
     ],
     zip_safe = False,
     install_requires = [
-        'django>=1.4,<1.5.99',
+        'Django>=1.4,<1.5.99',
     ],
 )


### PR DESCRIPTION
The django project declares it's name as "Django" not "django".

When we deploy we do so from static files to reduce network dependencies.  The command is something like this:

pip install --index-url='' -r requirements/apps.txt
with django-grappelli listed in apps.txt and available.  'django' works when hitting pypi and other network services, but pip doesn't match it to Django with it's setup.py: name = "Django"

This makes the right connection.
