### PR TITLE
Fix XSS in admin header

### DIFF
--- a/grappelli/templates/admin/includes_grappelli/header.html
+++ b/grappelli/templates/admin/includes_grappelli/header.html
@@ -6,7 +6,7 @@
         <ul id="grp-user-tools">
             <!-- Username -->
             <li class="grp-user-options-container grp-collapse grp-closed">
-                <a href="javascript://" class="user-options-handler grp-collapse-handler">{% firstof user.first_name user.username %}</a>
+                <a href="javascript://" class="user-options-handler grp-collapse-handler">{% filter force_escape %}{% firstof user.first_name user.username %}{% endfilter %}</a>
                 <ul class="grp-user-options">
                     <!-- Change Password -->
                     {% url 'admin:password_change' as password_change_url %}


### PR DESCRIPTION
The `firstof` template tag does not html escape its arguments, so when
using it to output something like a user's name, it must be wrapped with
`force_escape`.
