### PR TITLE
Make setup.py work with Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,8 @@
 import os
-import codecs
 from setuptools import setup, find_packages
 
 def read(fname):
-    return codecs.open(os.path.join(os.path.dirname(__file__), fname)).read()
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(
     name='django-grappelli',


### PR DESCRIPTION
codecs.open(foo) == open(foo) for text files
