### PR TITLE
Update grappelli/urls.py

### DIFF
--- a/grappelli/urls.py
+++ b/grappelli/urls.py
@@ -1,7 +1,12 @@
 # coding: utf-8
 
 # DJANGO IMPORTS
-from django.conf.urls.defaults import *
+
+try:
+  from django.conf.urls.defaults import *
+except ImportError:
+  from django.conf.urls import *
+  
 from django.views.generic.base import TemplateView
 from django.conf import settings
 


### PR DESCRIPTION
Hi
I'm working with django 1.6 (currently in development) and i'm having problems importing urls functionalities:

django.conf.urls.defaults will not work with django 1.6  use instead django.conf.urls
