### PR TITLE
Update grappelli/templates/admin/includes_grappelli/header.html to show custom user name

### DIFF
--- a/grappelli/templates/admin/includes_grappelli/header.html
+++ b/grappelli/templates/admin/includes_grappelli/header.html
@@ -6,7 +6,9 @@
         <ul id="grp-user-tools">
             <!-- Username -->
             <li class="grp-user-options-container grp-collapse grp-closed">
-                <a href="javascript://" class="user-options-handler grp-collapse-handler">{% firstof user.first_name user.username %}</a>
+                <a href="javascript://" class="user-options-handler grp-collapse-handler">
+                    {% firstof user.first_name user.username user.get_short_name %}        
+                </a>
                 <ul class="grp-user-options">
                     <!-- Change Password -->
                     {% url 'admin:password_change' as password_change_url %}


### PR DESCRIPTION
Notice that the name of the user is lost in the navigation bar:

![grappelli_no_username](https://f.cloud.github.com/assets/838679/55678/4726f686-5ae0-11e2-96b5-df0e5f356f8a.png)

If a programmer defines a custom user model (new in Django 1.5) with out first_name
or username fields then the user will not see its name or identification at the top right 
corner button (grp-user-options button).

with my change the template calls the  calls the new function get_short_name from
the customized user.

There are other options like get_username and get_full_name but i think get short
name is good for this case.

If the user don't define the method get_short_name in its custom user then the
name will be lost again.
 
