### PR TITLE
Distincts results of AutocompleteView.

### DIFF
--- a/grappelli/views/related.py
+++ b/grappelli/views/related.py
@@ -124,9 +124,7 @@ class AutocompleteLookup(RelatedLookup):
         qs = super(AutocompleteLookup, self).get_queryset()
         qs = self.get_filtered_queryset(qs)
         qs = self.get_searched_queryset(qs)
-        return qs
+        return qs.distinct()
 
     def get_data(self):
         return [{"value": f.pk, "label": get_label(f)} for f in self.get_queryset()[:AUTOCOMPLETE_LIMIT]]
-
-


### PR DESCRIPTION
When using related lookups (eg. `m2m__name`), AutocompleteView returns numerous times the same result.  That pull request fixes that.
