### PR TITLE
Fix RelatedLookup when called with empty string as object_id

### DIFF
--- a/grappelli/views/related.py
+++ b/grappelli/views/related.py
@@ -50,11 +50,12 @@ class RelatedLookup(View):
     def get_data(self):
         obj_id = self.GET['object_id']
         data = []
-        try:
-            obj = self.get_queryset().get(pk=obj_id)
-            data.append({"value": obj_id, "label": get_label(obj)})
-        except self.model.DoesNotExist:
-            data.append({"value": obj_id, "label": _("?")})
+        if obj_id:
+            try:
+                obj = self.get_queryset().get(pk=obj_id)
+                data.append({"value": obj_id, "label": get_label(obj)})
+            except self.model.DoesNotExist:
+                data.append({"value": obj_id, "label": _("?")})
         return data
 
     @never_cache


### PR DESCRIPTION
The RelatedLookup view got an empty string as `object_id` while creating objects via admin forms that contain autocomplete lookup fields.
