### PR TITLE
Make app title translatable in dashboard with django.utils.translation.gettext_noop

### DIFF
--- a/grappelli/dashboard/templates/grappelli/dashboard/modules/app_list.html
+++ b/grappelli/dashboard/templates/grappelli/dashboard/modules/app_list.html
@@ -4,7 +4,7 @@
     {% spaceless %}
     {% for child in module.children %}
         <div class="grp-module" id="module-{{child.title|lower}}">
-            <h{% if subindex %}4{% else %}3{% endif %}><a href="{{ child.url }}">{{ child.title }}</a></h{% if subindex %}4{% else %}3{% endif %}>
+            <h{% if subindex %}4{% else %}3{% endif %}><a href="{{ child.url }}">{% trans child.title %}</a></h{% if subindex %}4{% else %}3{% endif %}>
             {% for model in child.models %}
                 <div class="grp-row">
                     {% if model.admin_url %}


### PR DESCRIPTION
On the default admin index page you can translate the app titles by adding additional translation strings (with gettext_noop). For example:

``` python
from django.utils.translation import gettext_noop
gettext_noop("Auth")
```

This works only in the standard dashboard of Grappelli.
