### PR TITLE
Update grappelli/static/grappelli/tinymce/jscripts/tiny_mce/themes/advan...

### DIFF
--- a/grappelli/static/grappelli/tinymce/jscripts/tiny_mce/themes/advanced/skins/grappelli/content.css
+++ b/grappelli/static/grappelli/tinymce/jscripts/tiny_mce/themes/advanced/skins/grappelli/content.css
@@ -25,3 +25,5 @@
 @import url('content_base.css');
 @import url('content_typography.css');
 @import url('content_grid.css');
+
+.mcePageBreak {display:block;border:0;width:100%;height:15px;border-top:1px dotted #ccc;margin-top:15px;background:#fff url(img/icons/icon-mceResize.png) no-repeat center top;}


### PR DESCRIPTION
...ced/skins/grappelli/content.css

This is a quick and dirty fix to enable pagebreak visual representation using the mceResize icon
