### PR TITLE
Fixes issue with custom user models in Django 1.5

### DIFF
--- a/grappelli/templates/admin/includes_grappelli/header.html
+++ b/grappelli/templates/admin/includes_grappelli/header.html
@@ -6,7 +6,7 @@
         <ul id="grp-user-tools">
             <!-- Username -->
             <li class="grp-user-options-container grp-collapse grp-closed">
-                <a href="javascript://" class="user-options-handler grp-collapse-handler">{% firstof user.first_name user.username %}</a>
+                <a href="javascript://" class="user-options-handler grp-collapse-handler">{% firstof user.first_name user.username user.get_short_name user.get_username %}</a>
                 <ul class="grp-user-options">
                     <!-- Change Password -->
                     {% url 'admin:password_change' as password_change_url %}


### PR DESCRIPTION
Saw this (#265) and ran into the same problem with the username not showing when using a custom user in Django 1.5. This appears to fix the issue with Django 1.5 and is backwards compatible with Django 1.4. It's definitely longer than I'd like it to be (maybe a templatetag would be better?), but I tested it in Django 1.4 and Django 1.5 and it appears to have no ill side-effects.
