### PR TITLE
Handle import of django urls correctly.

### DIFF
--- a/grappelli/urls.py
+++ b/grappelli/urls.py
@@ -2,9 +2,9 @@
 
 # DJANGO IMPORTS
 try:
-    from django.conf.urls import *
+    from django.conf.urls import patterns, url
 except ImportError:
-    from django.conf.urls.defaults import *
+    from django.conf.urls.defaults import patterns, url
 
 from django.views.generic.base import TemplateView
 from .views.related import RelatedLookup, M2MLookup, AutocompleteLookup


### PR DESCRIPTION
Issue #264 lead to commit 1e8049d5b, which first attempted to import
from the old path, and on ImportError would import from the new path.
However, doing it that way leads to DeprecationWarnings bubbling up
in Django 1.5. The correct way is to try the new path _first_, and
if that fails, use the old path. This way it is backwards-compatible
and prevents DeprecationWarnings.

(@Troytft had it correct with commit 4b992de26a2 in issue #267.)
