### PR TITLE
Fixed a DeprecationWarning in Django 1.5

### DIFF
--- a/grappelli/urls.py
+++ b/grappelli/urls.py
@@ -2,9 +2,9 @@
 
 # DJANGO IMPORTS
 try:
-    from django.conf.urls.defaults import *  
-except ImportError:
     from django.conf.urls import *
+except ImportError:
+    from django.conf.urls.defaults import *
 
 from django.views.generic.base import TemplateView
 from .views.related import RelatedLookup, M2MLookup, AutocompleteLookup


### PR DESCRIPTION
Switched it so it tries to import django.conf.urls before django.conf.urls.defaults, in order to avoid DeprecationWarnings
