### PR TITLE
Fix deprecation warning in django 1.5. 

### DIFF
--- a/grappelli/urls.py
+++ b/grappelli/urls.py
@@ -1,10 +1,11 @@
 # coding: utf-8
 
 # DJANGO IMPORTS
-try:
-    from django.conf.urls.defaults import *  
-except ImportError:
-    from django.conf.urls import *
+try: 
+    from django.conf.urls import url, patterns
+except ImportError: 
+    # for Django version less then 1.4
+    from django.conf.urls.defaults import url, patterns
 
 from django.views.generic.base import TemplateView
 from .views.related import RelatedLookup, M2MLookup, AutocompleteLookup


### PR DESCRIPTION
This fix circumvents deprecation warnings, maintaining forwards and
backwards compatibility with Django 1.6 and 1.3. One can't simply
import *, since importing django.conf.urls won't fail under 1.3, but
WILL simply not import url() or patterns()

This code replaces pull requests https://github.com/sehmaschine/django-grappelli/pull/305 and https://github.com/sehmaschine/django-grappelli/pull/301 with code that isn't broken under django 1.3. Copied from the same issue which showed up in dajaxice here: https://github.com/jorgebastida/django-dajaxice/pull/95#issuecomment-15348897
