### PR TITLE
Fix for simplejson PendingDeprecationWarning Django 1.5+

### DIFF
--- a/grappelli/views/related.py
+++ b/grappelli/views/related.py
@@ -29,7 +29,7 @@ def get_label(f):
 
 
 def ajax_response(data):
-    return HttpResponse(simplejson.dumps(data), mimetype='application/javascript')
+    return HttpResponse(json.dumps(data), mimetype='application/javascript')
 
 
 class RelatedLookup(View):


### PR DESCRIPTION
This fixes the django.utils.simplejson PendingDeprecationWarning with Django 1.5.

Just as a note simplejson is also used in `templatetags/grp_tags.py` but a fix for 2.6 is already implemented.
