### PR TITLE
Avoiding Django 1.5 deprecation warnings on urls module

### DIFF
--- a/docs/dashboard_setup.rst
+++ b/docs/dashboard_setup.rst
@@ -40,7 +40,7 @@ Create a custom dashboard
 -------------------------
 
 To customize the index dashboard, you first need to add a custom dashboard::
-    
+
     python manage.py customdashboard
 
 This will create a file named ``dashboard.py`` in your project directory.
@@ -66,7 +66,7 @@ Create custom dashboards for multiple admin sites
 
 If you have several admin sites, you need to create a custom dashboard for each site::
 
-    from django.conf.urls.defaults import *
+    from django.conf.urls import include, patterns
     from django.contrib import admin
     from yourproject.admin import admin_site
 

--- a/grappelli/urls.py
+++ b/grappelli/urls.py
@@ -1,10 +1,7 @@
 # coding: utf-8
 
 # DJANGO IMPORTS
-try:
-    from django.conf.urls.defaults import *  
-except ImportError:
-    from django.conf.urls import *
+from django.conf.urls import patterns, url
 
 from django.views.generic.base import TemplateView
 from .views.related import RelatedLookup, M2MLookup, AutocompleteLookup


### PR DESCRIPTION
django.conf.urls.defaults is already too old; using it is triggering a DeprecationWarning on Django 1.5 setups and will be completely removed in Django 1.6. Time to change, right? :)
