### PR TITLE
Explicit python version support in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
     ],
     zip_safe = False,
 )


### PR DESCRIPTION
I assumed since this version supports Django 1.5, python 2.6 and 2.7 are supported as well. If python 3 is also supported add the appropriate versions from

```
Programming Language :: Python :: 3.0
Programming Language :: Python :: 3.1
Programming Language :: Python :: 3.2
Programming Language :: Python :: 3.3
```
