### PR TITLE
basque and spanish translations for jquery.ui.datepicker

### DIFF
--- a/grappelli/static/grappelli/jquery/i18n/ui.datepicker-es.js
+++ b/grappelli/static/grappelli/jquery/i18n/ui.datepicker-es.js
@@ -1,0 +1,19 @@
+﻿/* Spanish initialisation for the jQuery UI date picker plugin. */
+/* Written by Unai Zalakain (unai at gisa-elkartea dot org). */
+(function($){
+	$.datepicker.regional['es'] = {
+		closeText: 'Cerrar',
+		prevText: '&#x3c;Ant',
+		nextText: 'Sig&#x3e;',
+		currentText: 'Hoy',
+		monthNames: ['Enero','Febrero','Marzo','Abril','Mayo','Junio',
+		'Julio','Agosto','Septiembre','Octubre','Noviembre','Diciembre'],
+		monthNamesShort: ['Ene','Feb','Mar','Abr','May','Jun',
+		'Jul','Ago','Sep','Oct','Nov','Dic'],
+		dayNames: ['Domingo','Lunes','Martes','Miércoles','Jueves','Viernes','Sábado'],
+		dayNamesShort: ['Dom','Lun','Mar','Mir','Jue','Vie','Sáb'],
+		dayNamesMin: ['Do','Lu','Ma','Mi','Ju','Vi','Sá'],
+		dateFormat: 'dd-mm-yy', firstDay: 1,
+		isRTL: false};
+	$.datepicker.setDefaults($.datepicker.regional['es']);
+})(grp.jQuery);

--- a/grappelli/static/grappelli/jquery/i18n/ui.datepicker-eu.js
+++ b/grappelli/static/grappelli/jquery/i18n/ui.datepicker-eu.js
@@ -1,0 +1,20 @@
+﻿/* Basque initialisation for the jQuery UI date picker plugin. */
+/* Written by Unai Zalakain (unai at gisa-elkartea dot org). */
+(function($){
+	$.datepicker.regional['eu'] = {
+		closeText: 'Itxi',
+		prevText: '&#x3c;Aurr',
+		nextText: 'Hurr&#x3e;',
+		currentText: 'Gaur',
+		monthNames: ['Urtarrilla','Otsaila','Martxoa','Apirila','Maiatza','Ekaina',
+		'Uztaila','Abuztua','Iraila','Urria','Azaroa','Abendua'],
+		monthNamesShort: ['Urt','Ots','Mar','Api','Mai','Eka',
+		'Uzt','Abu','Ira','Urr','Aza','Abe'],
+		dayNames: ['Igandea','Astelehena','Asteartea','Azteazkena','Osteguna',
+        'Ostirala','Larunbata'],
+		dayNamesShort: ['Iga','Al','Ar','Az','Og','Ol','Lar'],
+		dayNamesMin: ['Ig','Al','Ar','Az','Os','Ol','Lr'],
+		dateFormat: 'yy-mm-dd', firstDay: 1,
+		isRTL: false};
+	$.datepicker.setDefaults($.datepicker.regional['eu']);
+})(grp.jQuery);


### PR DESCRIPTION
I had them translated by how the heck is it supposed to work? The translation file isn't even accessed. Django does it in a completely different way, isn't it better to stick with django's datepicker and apply custom CSS to it?
