### PR TITLE
Add support for generic lookups with radio field

### DIFF
--- a/grappelli/static/grappelli/js/jquery.grp_related_generic.js
+++ b/grappelli/static/grappelli/js/jquery.grp_related_generic.js
@@ -11,11 +11,12 @@
             return this.each(function() {
                 var $this = $(this);
                 // add placeholder
-                if ($(options.content_type).val()) {
-                    $this.after(options.placeholder).after(lookup_link($this.attr("id"),$(options.content_type).val()));
+                var val  = $(options.content_type).val() || $(options.content_type).find(':checked').val()
+                if (val) {
+                    $this.after(options.placeholder).after(lookup_link($this.attr('id'),val));
                 }
                 // lookup
-                if ($(options.content_type).val()) {
+                if (val) {
                     lookup_id($this, options); // lookup when loading page
                 }
                 $this.bind("change focus keyup", function() { // id-handler
@@ -52,8 +53,9 @@
         obj.val('');
         obj.parent().find('a.related-lookup').remove();
         obj.parent().find('.grp-placeholder-related-generic').remove();
-        if ($(elem).val()) {
-            obj.after(options.placeholder).after(lookup_link(obj.attr('id'),$(elem).val()));
+        var val  = $(elem).val() || $(elem).find(':checked').val()
+        if (val) {
+            obj.after(options.placeholder).after(lookup_link(obj.attr('id'),val));
         }
     };
     


### PR DESCRIPTION
Use of $(elem).val() for lookup_link generation doesn't work if
the content_type field is also in radio_fields. This change
checks $(elem).find(':checked').val() if $(elem).val() is false
