### PR TITLE
Fix alternative changelist template overflow issue

### DIFF
--- a/grappelli/compass/sass/partials/layout/_changelist.scss
+++ b/grappelli/compass/sass/partials/layout/_changelist.scss
@@ -1,6 +1,5 @@
 
 
-
 /*  PAGINATION
 ------------------------------------------------------------------------------------------------------ */
 
@@ -294,6 +293,9 @@ li.grp-changelist-actions {
 
 .grp-changelist-results {
 	background: $grp-module-background-color url('../images/backgrounds/changelist-results.png') repeat scroll !important;
+	overflow: auto;
+	overflow-y: hidden;
+	-ms-overflow-y: hidden;
 }
 
 body.grp-change-list {


### PR DESCRIPTION
Currently, when using the alternative changelist template (https://django-grappelli.readthedocs.org/en/2.4.4/customization.html#changelist-templates) and you have many columns (exceeding the width of the available screen "real state") some columns get under the alternative filters (on the right hand side) and a scrollbar appears on the browser level. Then, the last columns are nearly imposible to read because they always end up below the filters.

My proposal is to enable an horizontal scrollbar in the changelist results class so that the table won't go beyond its available space and a scrollbar will appear when needed.

A better solution would be to implement custom javascript scrollbars on the top and bottom of the changelist results div but this seems a good unobtrusive temporary fix.

![overflow](https://f.cloud.github.com/assets/1961274/493680/44e9954e-bb62-11e2-9664-52c602e2a1f7.png)
