### PR TITLE
Fix formatting of readonly fields in change forms

### DIFF
--- a/grappelli/templates/admin/includes/fieldset.html
+++ b/grappelli/templates/admin/includes/fieldset.html
@@ -19,7 +19,7 @@
                             <div class="c-1">{{ field.label_tag|prettylabel }}</div>
                             <div class="c-2">
                                 {% if field.is_readonly %}
-                                    <div class="grp-readonly">{{ field.contents }}</div>
+                                    <div class="grp-readonly">{{ field.contents|linebreaksbr }}</div>
                                 {% else %}
                                     {{ field.field }}
                                 {% endif %}

--- a/grappelli/templates/admin/includes/fieldset_inline.html
+++ b/grappelli/templates/admin/includes/fieldset_inline.html
@@ -19,7 +19,7 @@
                             <div class="c-1">{{ field.label_tag|prettylabel }}</div>
                             <div class="c-2">
                                 {% if field.is_readonly %}
-                                    <div class="grp-readonly">{{ field.contents }}</div>
+                                    <div class="grp-readonly">{{ field.contents|linebreaksbr }}</div>
                                 {% else %}
                                     {{ field.field }}
                                 {% endif %}


### PR DESCRIPTION
Django admin change forms normally render readonly fields with line breaks.  This makes Grappelli work the same way the default admin interface does for readonly fields.
