### PR TITLE
Escape autocompletion terms before passing them on to the request

### DIFF
--- a/grappelli/static/grappelli/js/jquery.grp_autocomplete_fk.js
+++ b/grappelli/static/grappelli/js/jquery.grp_autocomplete_fk.js
@@ -84,7 +84,7 @@
                     $.ajax({
                         url: options.autocomplete_lookup_url,
                         dataType: 'json',
-                        data: "term=" + request.term + "&app_label=" + grappelli.get_app_label(elem) + "&model_name=" + grappelli.get_model_name(elem) + "&query_string=" + grappelli.get_query_string(elem),
+                        data: "term=" + encodeURIComponent(request.term) + "&app_label=" + grappelli.get_app_label(elem) + "&model_name=" + grappelli.get_model_name(elem) + "&query_string=" + grappelli.get_query_string(elem),
                         beforeSend: function (XMLHttpRequest) {
                             options.loader.show();
                         },

--- a/grappelli/static/grappelli/js/jquery.grp_autocomplete_generic.js
+++ b/grappelli/static/grappelli/js/jquery.grp_autocomplete_generic.js
@@ -114,7 +114,7 @@
                     $.ajax({
                         url: options.autocomplete_lookup_url,
                         dataType: 'json',
-                        data: "term=" + request.term + "&app_label=" + grappelli.get_app_label(elem) + "&model_name=" + grappelli.get_model_name(elem) + "&query_string=" + grappelli.get_query_string(elem),
+                        data: "term=" + encodeURIComponent(request.term) + "&app_label=" + grappelli.get_app_label(elem) + "&model_name=" + grappelli.get_model_name(elem) + "&query_string=" + grappelli.get_query_string(elem),
                         beforeSend: function (XMLHttpRequest) {
                             var val = $(options.content_type).val() || $(options.content_type).find(':checked').val();
                             if (val) {

--- a/grappelli/static/grappelli/js/jquery.grp_autocomplete_m2m.js
+++ b/grappelli/static/grappelli/js/jquery.grp_autocomplete_m2m.js
@@ -138,7 +138,7 @@
                     $.ajax({
                         url: options.autocomplete_lookup_url,
                         dataType: 'json',
-                        data: "term=" + request.term + "&app_label=" + grappelli.get_app_label(elem) + "&model_name=" + grappelli.get_model_name(elem) + "&query_string=" + grappelli.get_query_string(elem),
+                        data: "term=" + encodeURIComponent(request.term) + "&app_label=" + grappelli.get_app_label(elem) + "&model_name=" + grappelli.get_model_name(elem) + "&query_string=" + grappelli.get_query_string(elem),
                         beforeSend: function (XMLHttpRequest) {
                             options.loader.show();
                         },


### PR DESCRIPTION
Otherwise queries like "a&b" are translated into a request URL like this:
http://.../autocomplete/term=a&b&...
