### PR TITLE
Add new approach to autocomplete_search_fields

### DIFF
--- a/grappelli/settings.py
+++ b/grappelli/settings.py
@@ -12,3 +12,6 @@ ADMIN_URL = getattr(settings, "GRAPPELLI_ADMIN_URL", '/admin/')
 
 # AUTOCOMPLETE LIMIT
 AUTOCOMPLETE_LIMIT = getattr(settings, "GRAPPELLI_AUTOCOMPLETE_LIMIT", 10)
+
+# Alternative approach to define autocomplete search fields
+AUTOCOMPLETE_SEARCH_FIELDS = getattr(settings, "GRAPPELLI_AUTOCOMPLETE_SEARCH_FIELDS", {})

--- a/grappelli/views/related.py
+++ b/grappelli/views/related.py
@@ -21,7 +21,7 @@ except ImportError:
     from django.utils import simplejson as json
 
 # GRAPPELLI IMPORTS
-from grappelli.settings import AUTOCOMPLETE_LIMIT
+from grappelli.settings import AUTOCOMPLETE_LIMIT, AUTOCOMPLETE_SEARCH_FIELDS
 
 
 def get_label(f):
@@ -118,6 +118,13 @@ class AutocompleteLookup(RelatedLookup):
     def get_searched_queryset(self, qs):
         model = self.model
         term = self.GET["term"]
+
+        try:
+            search_fields = model.autocomplete_search_fields()
+        except AttributeError:
+            search_fields = AUTOCOMPLETE_SEARCH_FIELDS[model._meta.app_label][model._meta.module_name]
+        except KeyError:
+            search_fields = ()
 
         for word in term.split():
             search = [models.Q(**{smart_str(item): smart_str(word)}) for item in model.autocomplete_search_fields()]


### PR DESCRIPTION
I found myself needing auto-complete on a model I couldn't alter, and felt wrapping it in a Proxy model was too much work for just this one case.

So I've added AUTOCOMPLETE_SEARCH_FIELDS to settings, which is a two-layer dict of [app_label][model_name] to get a list of search fields.

This way, you can augment 3rd party apps easily and cleanly, albeit in a slightly more limited fashion.

Also, if the requested model does not have any solution, it will no longer explode.
