### PR TITLE
Removes hard-coded urls from Django < 1.4.

### DIFF
--- a/grappelli/templates/admin/auth/user/change_password.html
+++ b/grappelli/templates/admin/auth/user/change_password.html
@@ -1,6 +1,6 @@
 {% extends "admin/base_site.html" %}
 {% load url from future %}
-{% load i18n admin_modify %} {# grp_csrf #}
+{% load i18n admin_modify admin_urls %} {# grp_csrf #}
 {% block userlinks %}
 {% url 'django-admindocs-docroot' as docsroot %}
     {% if docsroot %}
@@ -18,9 +18,10 @@
 {% block breadcrumbs %}
     {% if not is_popup %}
         <ul class="grp-horizontal-list">
-            <li><a href="../../../../">{% trans "Home" %}</a></li>
-            <li><a href="../../">{{ opts.verbose_name_plural|capfirst }}</a></li>
-            <li><a href="../">{{ original|truncatewords:"18" }}</a></li>
+            <li><a href="{% url 'admin:index' %}">{% trans "Home" %}</a></li>
+            <li><a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_label|capfirst|escape }}</a></li>
+            <li><a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a></li>
+            <li><a href="{% url opts|admin_urlname:'changelist' %}{{ original.pk }}">{{ original|truncatewords:"18" }}</a></li>
             <li>{% trans 'Change password' %}</li>
         </ul>
     {% endif %}

--- a/grappelli/templates/admin/change_form.html
+++ b/grappelli/templates/admin/change_form.html
@@ -2,7 +2,7 @@
 
 <!-- LOADING -->
 {% load url from future %}
-{% load admin_static i18n admin_modify grp_tags %}
+{% load admin_static i18n admin_modify grp_tags admin_urls %}
 
 <!-- STYLESHEETS -->
 {% block stylesheets %}
@@ -107,7 +107,7 @@
         <ul>
             <li><a href="../../../">{% trans "Home" %}</a></li>
             <li><a href="../../">{% trans app_label|capfirst|escape %}</a></li>
-            <li>{% if has_change_permission %}<a href="../">{{ opts.verbose_name_plural|capfirst }}</a>{% else %}{{ opts.verbose_name_plural|capfirst }}{% endif %}</li>
+            <li>{% if has_change_permission %}<a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>{% else %}{{ opts.verbose_name_plural|capfirst }}{% endif %}</li>
             <li>{% if add %}{% trans "Add" %} {{ opts.verbose_name }}{% else %}{{ original|truncatewords:"18" }}{% endif %}</li>
         </ul>
     {% endif %}

--- a/grappelli/templates/admin/change_list.html
+++ b/grappelli/templates/admin/change_list.html
@@ -2,7 +2,7 @@
 
 <!-- LOADING -->
 {% load url from future %}
-{% load admin_list i18n grp_tags %}
+{% load admin_list i18n grp_tags admin_urls %}
 
 <!-- STYLESHEETS -->
 {% block stylesheets %}
@@ -144,7 +144,7 @@
     {% if has_add_permission %}
         <ul class="grp-object-tools">
             {% block object-tools-items %}
-                <li><a href="add/{% if is_popup %}?_popup=1{% endif %}" class="grp-add-link grp-state-focus">{% blocktrans with cl.opts.verbose_name as name %}Add {{ name }}{% endblocktrans %}</a></li>
+                <li><a href="{% url cl.opts|admin_urlname:'add' %}{% if is_popup %}?_popup=1{% endif %}" class="grp-add-link grp-state-focus">{% blocktrans with cl.opts.verbose_name as name %}Add {{ name }}{% endblocktrans %}</a></li>
             {% endblock %}
         </ul>
     {% endif %}

--- a/grappelli/templates/admin/delete_confirmation.html
+++ b/grappelli/templates/admin/delete_confirmation.html
@@ -11,8 +11,8 @@
 <!-- BREADCRUMBS -->
 {% block breadcrumbs %}
     <ul class="grp-horizontal-list">
-        <li><a href="../../../../">{% trans "Home" %}</a></li>
-        <li><a href="../../../">{% trans app_label|capfirst|escape %}</a></li>
+        <li><a href="{% url 'admin:index' %}">{% trans "Home" %}</a></li>
+        <li><a href="{% url 'admin:app_list' app_label=opts.app_label %}">{% trans app_label|capfirst|escape %}</a></li>
         <li><a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst|escape }}</a></li>
         <li><a href="{% url opts|admin_urlname:'changelist' %}{{ object.pk }}">{{ object|truncatewords:"18" }}</a></lI>
         <li>{% trans 'Delete' %}</li>

--- a/grappelli/templates/admin/delete_selected_confirmation.html
+++ b/grappelli/templates/admin/delete_selected_confirmation.html
@@ -11,8 +11,8 @@
 <!-- BREADCRUMBS -->
 {% block breadcrumbs %}
     <ul class="grp-horizontal-list">
-        <li><a href="../../">{% trans "Home" %}</a></li>
-        <li><a href="../">{% trans app_label|capfirst|escape %}</a></li>
+        <li><a href="{% url 'admin:index' %}">{% trans "Home" %}</a></li>
+        <li><a href="{% url 'admin:app_list' app_label=app_label %}">{% trans app_label|capfirst|escape %}</a></li>
         <li><a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst|escape }}</a></li>
         <li>{% trans 'Delete multiple objects' %}</li>
     </ul>


### PR DESCRIPTION
Plus I added a missing line related to the new customizable user model (but that should also work with 1.4).
