### PR TITLE
Added support for needs_explicit_pk_field

### DIFF
--- a/grappelli/templates/admin/edit_inline/stacked.html
+++ b/grappelli/templates/admin/edit_inline/stacked.html
@@ -41,8 +41,8 @@
                 {% for fieldset in inline_admin_form %}
                     {% include "admin/includes/fieldset_inline.html" %}
                 {% endfor %}
-                {{ inline_admin_form.pk_field.field }}
                 {{ inline_admin_form.fk_field.field }}
+                {% if inline_admin_form.has_auto_field or inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
             </div>
         {% endfor %}
         {% endwith %}

--- a/grappelli/templates/admin/edit_inline/tabular.html
+++ b/grappelli/templates/admin/edit_inline/tabular.html
@@ -78,7 +78,7 @@
                         {% endspaceless %}
                     </div>
                     {{ inline_admin_form.fk_field.field }}
-                    {% if inline_admin_form.has_auto_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
+                    {% if inline_admin_form.has_auto_field or inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
                 </div>
             </div>
         {% endfor %}


### PR DESCRIPTION
Django 1.6b2 removed has_auto_field and replaced it with
needs_explicit_pk_field.  With just has_auto_field, inlines are unusable
in 1.6b2.  The needs_explicit_pk_field was also backported to Django
1.5, but I don't know what version that affects.  The change maintains
backwards compatibility by also checking has_auto_field.

I also added the needs_explicit_pk_field/has_auto_field check to the
stacked template in order to support models where the PK field is
editable.
