### PR TITLE
Added a new block called "admin_title" that allows for greater customization of the main header title

### DIFF
--- a/grappelli/templates/admin/base.html
+++ b/grappelli/templates/admin/base.html
@@ -71,7 +71,7 @@
 
                 <!-- NAVIGATION -->
                 <div id="grp-navigation">
-                    <h1 id="grp-admin-title">{% if grappelli_admin_title %}{{ grappelli_admin_title }}{% else %}{% get_admin_title %}{% endif %}</h1>
+                    {% block admin_title %}<h1 id="grp-admin-title">{% if grappelli_admin_title %}{{ grappelli_admin_title }}{% else %}{% get_admin_title %}{% endif %}</h1>{% endblock %}
                     {% if user.is_authenticated and user.is_staff %}
                         <ul id="grp-user-tools">
                             <!-- Userlinks -->


### PR DESCRIPTION
This tweak came about when I had the need to put an image next to the title displayed on the main header.  I can make it work with the current version doing this...

``` python
GRAPPELLI_ADMIN_TITLE = "<img src='logo.png'> Admin Title"
```

But I'd rather be able to further customize the html in the header...also, the solution above seems a little kludgy.

To me, it makes more sense to be able to put this in the admin base_site.html

``` html
{% block admin_title %}
<img src='logo.png'> Admin Title
{% endblock %}
```

PS: This is my first time contributing to a project on git.  If I did any of this incorrectly, please forgive me :)
