### PR TITLE
Remove hardcoded URLs from change_form.html

### DIFF
--- a/grappelli/templates/admin/change_form.html
+++ b/grappelli/templates/admin/change_form.html
@@ -118,8 +118,8 @@
 {% block breadcrumbs %}
     {% if not is_popup %}
         <ul>
-            <li><a href="../../../">{% trans "Home" %}</a></li>
-            <li><a href="../../">{% trans app_label|capfirst|escape %}</a></li>
+            <li><a href="{% url 'admin:index' %}">{% trans "Home" %}</a></li>
+            <li><a href="{% url 'admin:app_list' app_label=opts.app_label %}">{% trans app_label|capfirst|escape %}</a></li>
             <li>{% if has_change_permission %}<a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>{% else %}{{ opts.verbose_name_plural|capfirst }}{% endif %}</li>
             <li>{% if add %}{% trans "Add" %} {{ opts.verbose_name }}{% else %}{{ original|truncatewords:"18" }}{% endif %}</li>
         </ul>
@@ -132,8 +132,9 @@
         {% if not is_popup %}
             <ul class="grp-object-tools">
                 {% block object-tools-items %}
-                    <li><a href="history/">{% trans "History" %}</a></li>
-                    {% if has_absolute_url %}<li><a href="../../../r/{{ content_type_id }}/{{ object_id }}/" class="grp-state-focus" target="_blank">{% trans "View on site" %}</a></li>{% endif%}
+                    {% url opts|admin_urlname:'history' original.pk|admin_urlquote as history_url %}
+                    <li><a href="{% add_preserved_filters history_url %}">{% trans "History" %}</a></li>
+                    {% if has_absolute_url %}<li><a href="{% url 'admin:view_on_site' content_type_id original.pk %}" class="grp-state-focus" target="_blank">{% trans "View on site" %}</a></li>{% endif%}
                 {% endblock %}
             </ul>
         {% endif %}


### PR DESCRIPTION
This commit port the following fixes from Django to grappelli:
django/django@aaf77c1676e44019abe544911ff7a06eb2690295
by Ramiro Morales (cramm0 at gmail.com)

django/django@c86a9b63984f6692d478f6f70e3c78de4ec41814
by Loic Bistuer (loic.bistuer at sixmedia.com)

django/django@aee9eecb920cf281e8339a5f7edadc6f2dd04fea
by Daniel Hepper (daniel.hepper at gmail.com)
