### PR TITLE
Django 1.6 removed the has_auto_field on admin forms

### DIFF
--- a/grappelli/templates/admin/edit_inline/tabular.html
+++ b/grappelli/templates/admin/edit_inline/tabular.html
@@ -78,7 +78,7 @@
                         {% endspaceless %}
                     </div>
                     {{ inline_admin_form.fk_field.field }}
-                    {% if inline_admin_form.has_auto_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
+                    {% if inline_admin_form.needs_explicit_pk_field or inline_admin_form.has_auto_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
                 </div>
             </div>
         {% endfor %}


### PR DESCRIPTION
It's named needs_explicit_pk_field now. In order to support all versions of Django, output the pk field if either property is true.

See https://code.djangoproject.com/ticket/13696
