### PR TITLE
This patch started as an adaptation of the fix described at http://stack...

### DIFF
--- a/grappelli/templates/admin/edit_inline/stacked.html
+++ b/grappelli/templates/admin/edit_inline/stacked.html
@@ -44,6 +44,15 @@
                 {{ inline_admin_form.fk_field.field }}
                 {% if inline_admin_form.has_auto_field or inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
             </div>
+            {% if forloop.last %}
+              <script type="text/javascript">
+                if (tinyMCE != undefined) {
+                  django.jQuery('textarea', '.grp-empty-form').each(function() {
+                    tinyMCE.execCommand('mceRemoveControl', false, django.jQuery(this).attr('id'));
+                  });
+                }
+              </script>
+            {% endif %}
         {% endfor %}
         {% endwith %}
         {{ inline_admin_formset.extra_forms }}
@@ -134,30 +143,43 @@
         
         $("#{{ inline_admin_formset.formset.prefix }}-group").grp_inline({
             prefix: "{{ inline_admin_formset.formset.prefix }}",
-            onBeforeAdded:function(form) {
-                // New inlines start as a hidden template with class grp-empty-form.
-                // This contains a textarea, which TinyMCE converts correctly, but
-                // something about the transformation from template to visible 
-                // form breaks TinyMCE, so:
-                
-                // We need to find every tinyMCE instance...
-               django.jQuery(tinyMCE.get()).each(function() { 
-                   // ...that is inside a grp-empty-form...
-                   django.jQuery(".grp-empty-form #" + django.jQuery(this).attr("id")).each(function() { 
-                       // ...and remove it, so it can be re-initialized in onAfterAdded()
-                       tinyMCE.execCommand("mceRemoveControl",false,django.jQuery(this).attr("id")) 
-                    }) 
-                })
-            },
-            onAfterRemoved: function(inline) {},
-            onAfterAdded: function(form) {               
+              onBeforeRemoved: function(f) {
+               if (tinyMCE != undefined) {
+                   // make sure tinyMCE instances in empty-form are inactive
+                   // find every tinyMCE instance...
+                   django.jQuery(tinyMCE.get()).each(function() { 
+                       // ...that is inside a grp-empty-form...
+                       django.jQuery(".grp-empty-form #" + django.jQuery(this).attr("id")).each(function() { 
+                           // ...and remove it, so it can be re-initialized in onAfterAdded()
+                           tinyMCE.execCommand("mceRemoveControl",false,django.jQuery(this).attr("id")) 
+                        }) 
+                    })
+               }
+              },
+              onAfterRemoved: function(form) {
+              },
+              onBeforeAdded: function(form) {
                 if (tinyMCE != undefined) {
-                  // re-initialise tinyMCE
-                  tinyMCE.init(tinyMCE.settings);
+                  // make sure tinyMCE instances in empty-form are inactive
+                  django.jQuery('textarea', '.grp-empty-form').each(function() {
+                    tinyMCE.execCommand('mceRemoveControl', false, django.jQuery(this).attr('id'));
+                  }); 
                 }
-                // Ensure that the new inline appears
-                // un-collapsed, even if inlines are collapsed by default
-                django.jQuery(form).removeClass("grp-closed").addClass("grp-open");
+              },
+              onAfterAdded: function(form) {
+                console.log("onAfterAdded");
+                if (tinyMCE != undefined) {
+                  // re-initialise tinyMCE instances
+                  $('textarea', form).each(function(k,v) {
+                    var tid = $(this).attr('id');
+                    tinyMCE.execCommand('mceRemoveControl', false, tid);
+                    tinyMCE.execCommand('mceAddControl', false, tid);
+                  });
+                  // make sure tinyMCE instances in empty-form are inactive
+                  django.jQuery('textarea', '.empty-form').each(function() {
+                    tinyMCE.execCommand('mceRemoveControl', false, django.jQuery(this).attr('id'));
+                  });
+                }            
                 
                 grappelli.reinitDateTimeFields(form);
                 grappelli.updateSelectFilter(form);

--- a/grappelli/templates/admin/edit_inline/stacked.html
+++ b/grappelli/templates/admin/edit_inline/stacked.html
@@ -134,8 +134,31 @@
         
         $("#{{ inline_admin_formset.formset.prefix }}-group").grp_inline({
             prefix: "{{ inline_admin_formset.formset.prefix }}",
+            onBeforeAdded:function(form) {
+                // New inlines start as a hidden template with class grp-empty-form.
+                // This contains a textarea, which TinyMCE converts correctly, but
+                // something about the transformation from template to visible 
+                // form breaks TinyMCE, so:
+                
+                // We need to find every tinyMCE instance...
+               django.jQuery(tinyMCE.get()).each(function() { 
+                   // ...that is inside a grp-empty-form...
+                   django.jQuery(".grp-empty-form #" + django.jQuery(this).attr("id")).each(function() { 
+                       // ...and remove it, so it can be re-initialized in onAfterAdded()
+                       tinyMCE.execCommand("mceRemoveControl",false,django.jQuery(this).attr("id")) 
+                    }) 
+                })
+            },
             onAfterRemoved: function(inline) {},
-            onAfterAdded: function(form) {
+            onAfterAdded: function(form) {               
+                if (tinyMCE != undefined) {
+                  // re-initialise tinyMCE
+                  tinyMCE.init(tinyMCE.settings);
+                }
+                // Ensure that the new inline appears
+                // un-collapsed, even if inlines are collapsed by default
+                django.jQuery(form).removeClass("grp-closed").addClass("grp-open");
+                
                 grappelli.reinitDateTimeFields(form);
                 grappelli.updateSelectFilter(form);
                 $.each(related_lookup_fields_fk, function() {


### PR DESCRIPTION
This patch started as an adaptation of the fix described at http://stackoverflow.com/questions/5738173/

Based on a suggestion by Patrick on the grappelli Google group, it has been further modified so that it should work with any tinyMCE mode setting, not just "textfields". 

See also https://groups.google.com/forum/#!topic/django-grappelli/hU_e2qmN_uc