### PR TITLE
Renamed the 'mimetype' arg to 'content_type'

### DIFF
--- a/grappelli/views/related.py
+++ b/grappelli/views/related.py
@@ -32,7 +32,7 @@ def get_label(f):
 
 
 def ajax_response(data):
-    return HttpResponse(json.dumps(data), mimetype='application/javascript')
+    return HttpResponse(json.dumps(data), content_type='application/javascript')
 
 
 class RelatedLookup(View):


### PR DESCRIPTION
'content_type' was introduced in Django 1.0 to replace 'mimetype', they kept the compatibility until 1.5 but it's now gone in 1.6.
See https://github.com/django/django/commit/8eadbc5a03d06f5bfedfa3fad35ad0801d2ab6ff and https://docs.djangoproject.com/en/1.6/ref/request-response/#django.http.HttpResponse.__init__
