### PR TITLE
RelatedObjectLookups.js updates accordingly to Django 1.6 changes

### DIFF
--- a/grappelli/static/admin/js/admin/RelatedObjectLookups.js
+++ b/grappelli/static/admin/js/admin/RelatedObjectLookups.js
@@ -86,14 +86,14 @@ function dismissAddAnotherPopup(win, newId, newRepr) {
     var name = windowname_to_id(win.name);
     var elem = document.getElementById(name);
     if (elem) {
-        if (elem.nodeName == 'SELECT') {
+        var elemName = elem.nodeName.toUpperCase();
+        if (elemName == 'SELECT') {
             var o = new Option(newRepr, newId);
             elem.options[elem.options.length] = o;
             o.selected = true;
-        } else if (elem.nodeName == 'INPUT') {
+        } else if (elemName == 'INPUT') {
             if (elem.className.indexOf('vManyToManyRawIdAdminField') != -1 && elem.value) {
                 elem.value += ',' + newId;
-                elem.focus();
             } else {
                 elem.value = newId;
                 elem.focus();


### PR DESCRIPTION
Old version of showRelatedObjectLookupPopup function breaks raw id fields popups (they are rendered as regular change list views) when using Django 1.6, these changes are not backward compatible with Django <= 1.5.5 though.
