### PR TITLE
 RelatedObjectLookups.js updates accordingly to Django 1.6 changes

### DIFF
--- a/grappelli/static/admin/js/admin/RelatedObjectLookups.js
+++ b/grappelli/static/admin/js/admin/RelatedObjectLookups.js
@@ -40,7 +40,7 @@ function showRelatedObjectLookupPopup(triggeringLink) {
     var win = window.open(href, name, 'height=500,width=1000,resizable=yes,scrollbars=yes');
     win.focus();
     return false;
-    }
+}
 
 function dismissRelatedLookupPopup(win, chosenId) {
     var name = windowname_to_id(win.name);


### PR DESCRIPTION
Old version of showRelatedObjectLookupPopup function breaks raw id fields popups (they are rendered as regular change list views) when using Django 1.6, these changes are not backward compatible with Django <= 1.5.5 though.
