### PR TITLE
Update RelatedObjectLookups.js

### DIFF
--- a/grappelli/static/admin/js/admin/RelatedObjectLookups.js
+++ b/grappelli/static/admin/js/admin/RelatedObjectLookups.js
@@ -95,11 +95,10 @@ function dismissAddAnotherPopup(win, newId, newRepr) {
         } else if (elemName == 'INPUT') {
             if (elem.className.indexOf('vManyToManyRawIdAdminField') != -1 && elem.value) {
                 elem.value += ',' + newId;
-                elem.focus();
             } else {
                 elem.value = newId;
-                elem.focus();
             }
+            elem.focus();
         }
     } else {
         var toId = name + "_to";


### PR DESCRIPTION
adding back elem.focus() to dismissAddAnotherPopup, not having them results in a not update of the representation when Adding a new related.
