### PR TITLE
Fixed version which added Rearrange Inlines.

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -114,7 +114,7 @@ You may want to define ``sortable_excludes`` (either list or tuple) in order to 
 Rearrange Inlines
 -----------------
 
-.. versionadded:: 2.4
+.. versionadded:: 2.4.6
 
 Sometimes it might make sense to not show inlines at the bottom of the page/form, but somewhere in–between. In order to achieve this, you need to define a placeholder with your fields/fieldsets in admin.py::
 


### PR DESCRIPTION
I was running 2.4.4 which doesn't actually have Rearrange Inlines. Not sure if your policy is to only mention MAJOR.MINOR as the version that added a feature. But only 2.4.6 and forward have this. See 2aff65acd27b138e24aae517d84ec15b522f14af.
