### PR TITLE
Sortable inlines with support for manually set, negative order values

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,8 @@ Changelog
 2.5.1 (not yet released)
 ------------------------
 
+* Improved: Support setting negative sortable field order values in sortable inlines, so that they get moved to the top on submit.
+
 2.5.0 (November 13th, 2013)
 ---------------------------
 

--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -91,6 +91,7 @@ Now, define the ``sortable_field_name`` with your ``InlineModelAdmin``::
         sortable_field_name = "position"
 
 The inline rows are reordered based on the sortable field (with a templatetag ``formsetsort``). When submitting a form, the values of the sortable field are reindexed according to the position of each row.
+You can manually set negative sortable field order values, so that the inline rows are moved to the top on submit.
 In case of errors (somewhere within the form), the position of inline rows is preserved. This also applies to rows prepared for deletion while empty rows are being moved to the end of the formset.
 
 .. _customizationsortableexcludes:
@@ -142,7 +143,7 @@ With Grappelli, you're able to add the representation of an object beneath the i
     class MyModel(models.Model):
         related_fk = models.ForeignKey(RelatedModel, verbose_name=u"Related Lookup (FK)")
         related_m2m = models.ManyToManyField(RelatedModel, verbose_name=u"Related Lookup (M2M)")
-    
+
     class MyModelOptions(admin.ModelAdmin):
         # define the raw_id_fields
         raw_id_fields = ('related_fk','related_m2m',)
@@ -157,7 +158,7 @@ With generic relations, related lookups are defined like this::
     from django.contrib.contenttypes import generic
     from django.contrib.contenttypes.models import ContentType
     from django.db import models
-    
+
     class MyModel(models.Model):
         # first generic relation
         content_type = models.ForeignKey(ContentType, blank=True, null=True, related_name="content_type")
@@ -167,7 +168,7 @@ With generic relations, related lookups are defined like this::
         relation_type = models.ForeignKey(ContentType, blank=True, null=True, related_name="relation_type")
         relation_id = models.PositiveIntegerField(blank=True, null=True)
         relation_object = generic.GenericForeignKey("relation_type", "relation_id")
-    
+
     class MyModelOptions(admin.ModelAdmin):
         # define the related_lookup_fields
         related_lookup_fields = {
@@ -178,7 +179,7 @@ If your generic relation points to a model using a custom primary key, you need 
 
     class RelationModel(models.Model):
         cpk  = models.IntegerField(primary_key=True, unique=True, editable=False)
-        
+
         @property
         def id(self):
             return self.cpk
@@ -189,7 +190,7 @@ Example in Python 2 ::
 
     def __unicode__(self):
         return u"%s" % self.name
-    
+
     def related_label(self):
         return u"%s (%s)" % (self.name, self.id)
 
@@ -197,7 +198,7 @@ Example in Python 3 ::
 
     def __str__(self):
         return "%s" % self.name
-    
+
     def related_label(self):
         return "%s (%s)" % (self.name, self.id)
 
@@ -220,7 +221,7 @@ Add the staticmethod ``autocomplete_search_fields`` to all models you want to se
 
     class MyModel(models.Model):
         name = models.CharField(u"Name", max_length=50)
-    
+
         @staticmethod
         def autocomplete_search_fields():
             return ("id__iexact", "name__icontains",)
@@ -238,7 +239,7 @@ Defining autocomplete lookups is very similar to related lookups::
     class MyModel(models.Model):
         related_fk = models.ForeignKey(RelatedModel, verbose_name=u"Related Lookup (FK)")
         related_m2m = models.ManyToManyField(RelatedModel, verbose_name=u"Related Lookup (M2M)")
-    
+
     class MyModelOptions(admin.ModelAdmin):
         # define the raw_id_fields
         raw_id_fields = ('related_fk','related_m2m',)
@@ -253,7 +254,7 @@ This also works with generic relations::
     from django.contrib.contenttypes import generic
     from django.contrib.contenttypes.models import ContentType
     from django.db import models
-    
+
     class MyModel(models.Model):
         # first generic relation
         content_type = models.ForeignKey(ContentType, blank=True, null=True, related_name="content_type")
@@ -263,7 +264,7 @@ This also works with generic relations::
         relation_type = models.ForeignKey(ContentType, blank=True, null=True, related_name="relation_type")
         relation_id = models.PositiveIntegerField(blank=True, null=True)
         relation_object = generic.GenericForeignKey("relation_type", "relation_id")
-    
+
     class MyModelOptions(admin.ModelAdmin):
         # define the autocomplete_lookup_fields
         autocomplete_lookup_fields = {
@@ -274,13 +275,13 @@ If your generic relation points to a model using a custom primary key, you need 
 
     class RelationModel(models.Model):
         cpk  = models.IntegerField(primary_key=True, unique=True, editable=False)
-        
+
         @property
         def id(self):
             return self.cpk
 
 If the human-readable value of a field you are searching on is too large to be indexed (e.g. long text as SHA key) or is saved in a different format (e.g. date as integer timestamp), add a staticmethod ``autocomplete_term_adjust`` to the corresponding model with the appropriate transformation and perform the lookup on the indexed field::
-    
+
     class MyModel(models.Model):
         text = models.TextField(u"Long text")
         text_hash = models.CharField(u"Text hash", max_length=40, unique=True)
@@ -299,7 +300,7 @@ Example in Python 2 ::
 
     def __unicode__(self):
         return u"%s" % self.name
-    
+
     def related_label(self):
         return u"%s (%s)" % (self.name, self.id)
 
@@ -307,7 +308,7 @@ Example in Python 3 ::
 
     def __str__(self):
         return "%s" % self.name
-    
+
     def related_label(self):
         return "%s (%s)" % (self.name, self.id)
 

--- a/grappelli/templates/admin/edit_inline/stacked.html
+++ b/grappelli/templates/admin/edit_inline/stacked.html
@@ -130,7 +130,7 @@
                 }
             });
         });
-        
+
         $("#{{ inline_admin_formset.formset.prefix }}-group").grp_inline({
             prefix: "{{ inline_admin_formset.formset.prefix }}",
             onAfterRemoved: function(inline) {},
@@ -198,7 +198,7 @@
                 form.find(".grp-collapse").grp_collapsible();
             }
         });
-        
+
         {% if inline_admin_formset.opts.sortable_field_name %}
         $("#{{ inline_admin_formset.formset.prefix }}-group > div.grp-items").sortable({
             handle: "a.grp-drag-handler",
@@ -218,6 +218,24 @@
             var sortable_field_name = "{{ inline_admin_formset.opts.sortable_field_name }}",
                 sortable_excludes = {% get_sortable_excludes inline_admin_formset.opts %},
                 i = 0;
+
+            // Move items with a manually set, negative index to the top before auto updating positions.
+            var _pos_id_list = new Array();
+            // Find all items with negative positions and add save both their position and id attributes.
+            $("#{{ inline_admin_formset.formset.prefix }}-group").find("div.grp-dynamic-form").each(function(){
+                var pos_val = parseInt($(this).find("input[name$='"+sortable_field_name+"']").val());
+                if (pos_val < 0) {
+                    _pos_id_list.push({'pos': pos_val, 'id': $(this).attr('id')});
+                }
+            });
+            // Reverse sort the position-id-objects
+            _pos_id_list.sort(function(obj1, obj2) { return obj2.pos - obj1.pos });
+            // Iterate through the reversed position-id-objects and move the items to the top.
+            $.each(_pos_id_list, function() {
+                var obj = $('#' + this.id);
+                obj.parent().prepend(obj);
+            });
+
             $("#{{ inline_admin_formset.formset.prefix }}-group").find("div.grp-dynamic-form").each(function(){
                 var fields = $(this).find("fieldset :input[type!=radio][type!=checkbox],input:checked,input[type=file]"),
                     submit_values = false,
@@ -238,7 +256,7 @@
             });
         });
         {% endif %}
-        
+
     });
 })(grp.jQuery);
 </script>

--- a/grappelli/templates/admin/edit_inline/tabular.html
+++ b/grappelli/templates/admin/edit_inline/tabular.html
@@ -97,7 +97,7 @@
 <script type="text/javascript">
 (function($) {
     $(document).ready(function($) {
-        
+
         var prefix = "{{ inline_admin_formset.formset.prefix }}";
         var related_lookup_fields_fk = {% get_related_lookup_fields_fk inline_admin_formset.opts %};
         var related_lookup_fields_m2m = {% get_related_lookup_fields_m2m inline_admin_formset.opts %};
@@ -168,7 +168,7 @@
                 }
             });
         });
-        
+
         $("#{{ inline_admin_formset.formset.prefix }}-group").grp_inline({
             prefix: "{{ inline_admin_formset.formset.prefix }}",
             onBeforeAdded: function(inline) {},
@@ -234,7 +234,7 @@
                 });
             }
         });
-        
+
         {% if inline_admin_formset.opts.sortable_field_name %}
         $("#{{ inline_admin_formset.formset.prefix }}-group > div.grp-table").sortable({
             handle: "a.grp-drag-handler",
@@ -266,6 +266,22 @@
             var sortable_field_name = "{{ inline_admin_formset.opts.sortable_field_name }}",
                 sortable_excludes = {% get_sortable_excludes inline_admin_formset.opts %},
                 i = 0;
+            // Move items with a manually set, negative index to the top before auto updating positions.
+            var _pos_id_list = new Array();
+            // Find all items with negative positions and add save both their position and id attributes.
+            $("#{{ inline_admin_formset.formset.prefix }}-group").find("div.grp-tbody.grp-dynamic-form").each(function(){
+                var pos_val = parseInt($(this).find("input[name$='"+sortable_field_name+"']").val());
+                if (pos_val < 0) {
+                    _pos_id_list.push({'pos': pos_val, 'id': $(this).attr('id')});
+                }
+            });
+            // Reverse sort the position-id-objects
+            _pos_id_list.sort(function(obj1, obj2) { return obj2.pos - obj1.pos });
+            // Iterate through the reversed position-id-objects and move the items to the top.
+            $.each(_pos_id_list, function() {
+                var obj = $('#' + this.id);
+                obj.parent().prepend(obj);
+            });
             $("#{{ inline_admin_formset.formset.prefix }}-group").find("div.grp-tbody.grp-dynamic-form").each(function(){
                 var fields = $(this).find("div.grp-td :input[type!=radio][type!=checkbox],input:checked,input[type=file]"),
                     submit_values = false,
@@ -287,7 +303,7 @@
             });
         });
         {% endif %}
-        
+
     });
 })(grp.jQuery);
 </script>


### PR DESCRIPTION
We have long lists of inline sortables. Every time a new inline gets added, it gets stored at the end of the list, but should be at the very top in our use case. Since we have the order field in place, I think it's easier to enter a negative position value and move those inlines at the very top upon submission than having to drag them through the list using the mouse.
