### PR TITLE
Fixed the Exception chains in autocomplete

### DIFF
--- a/grappelli/views/related.py
+++ b/grappelli/views/related.py
@@ -127,9 +127,10 @@ class AutocompleteLookup(RelatedLookup):
         try:
             search_fields = model.autocomplete_search_fields()
         except AttributeError:
-            search_fields = AUTOCOMPLETE_SEARCH_FIELDS[model._meta.app_label][model._meta.module_name]
-        except KeyError:
-            search_fields = ()
+            try:
+                search_fields = AUTOCOMPLETE_SEARCH_FIELDS[model._meta.app_label][model._meta.module_name]
+            except KeyError:
+                search_fields = ()
 
         for word in term.split():
             search = [models.Q(**{smart_text(item): smart_text(word)}) for item in search_fields]


### PR DESCRIPTION
Waring: This fix is incomplete.
The intention of "except KeyError" was to catch on the AUTOCOMPLETE_SEARCH_FIELDS access. Although, in the original code, this will never be reach, as the "except KeyError" is only catching on the "model.autocomplete_search_fields()".
This patch fix the first issue, although I'm not fan of nested exceptions.
Also, in the case neither of the autocomplete_search_fields() nor AUTOCOMPLETE_SEARCH_FIELDS was declared for the current lookup, the "search_fields = ()" assignment will make the QuerySet creation fail.
Therefore, I think this patch is incomplete and the logic of this method needs to be refactored.
Let me know what's your take on the issue. Thanks.
