### PR TITLE
Fixes PendingDeprecationWarning at Django 1.6

### DIFF
--- a/grappelli/templates/admin/change_list_results.html
+++ b/grappelli/templates/admin/change_list_results.html
@@ -1,3 +1,4 @@
+{% load cycle from future %}
 {% load i18n admin_static %}
 {% if result_hidden_fields %}
     <div class="hiddenfields"> {# DIV for HTML validation #}


### PR DESCRIPTION
'The `cycle` template tag is changing to escape its arguments; the non-autoescaping version is deprecated. Load it from the `future` tag library to start using the new behavior.
