### PR TITLE
Fix padding in the "insert table" dialog in TinyMCE

### DIFF
--- a/grappelli/static/grappelli/tinymce/jscripts/tiny_mce/plugins/table/table.htm
+++ b/grappelli/static/grappelli/tinymce/jscripts/tiny_mce/plugins/table/table.htm
@@ -11,7 +11,6 @@
 	<link href="css/table.css" rel="stylesheet" type="text/css" />
 </head>
 <body id="table" style="display: none" role="application" aria-labelledby="app_title">
-	<span style="display:none;" id="app_title">{#table_dlg.title}</span>
 	<form onsubmit="insertTable();return false;" action="#">
 		<div class="tabs">
 			<ul>


### PR DESCRIPTION
VERSIONS: Grappelli 2.5.1, Django 1.6.1
STATICFILES: OK.
JAVASCRIPTS: OK
CUSTOMIZATIONS: NONE

If you enable the "table" plugin in TinyMCE and try to insert a table, the table dialog has no margin on the top. That's because the "body > *:first-child { margin-top: 20px }" CSS rule gets applied to an invisible element.
