### PR TITLE
Italian initialisation for the jQuery UI date picker plugin added

### DIFF
--- a/grappelli/static/grappelli/jquery/i18n/ui.datepicker-it.js
+++ b/grappelli/static/grappelli/jquery/i18n/ui.datepicker-it.js
@@ -10,7 +10,7 @@
 		'Luglio','Agosto','Settembre','Ottobre','Novembre','Dicembre'],
 		monthNamesShort: ['Gen','Feb','Mar','Apr','Mag','Giu',
 		'Lug','Ago','Set','Ott','Nov','Dic'],
-		dayNames: ['Domenica','Lunedì','Martedì','Mercoledì','Giiovedì','Venerdì','Sabato'],
+		dayNames: ['Domenica','Lunedì','Martedì','Mercoledì','Giovedì','Venerdì','Sabato'],
 		dayNamesShort: ['Dom','Lun','Mar','Mer','Gio','Ven','Sab'],
 		dayNamesMin: ['Do','Lu','Ma','Me','Gi','Ve','Sa'],
 		dateFormat: 'dd-mm-yy',


### PR DESCRIPTION
Not sure whether this is the right place to commit; ideally, should be pulled to jquery repo instead.
However, since the original jQuery files are already customized to add "grp.jQuery" namespace, could be eventually useful.
