### PR TITLE
Remove unknown variable: `onclick_attrib`

### DIFF
--- a/grappelli/templates/admin/submit_line.html
+++ b/grappelli/templates/admin/submit_line.html
@@ -6,16 +6,16 @@
             <li class="grp-float-left"><a href="delete/" class="grp-button grp-delete-link">{% trans "Delete" %}</a></li>
         {% endif %}
         {% if show_save %}
-        	<li><input type="submit" value="{% trans 'Save' %}" class="grp-button grp-default" name="_save" {{ onclick_attrib }}/></li>
+            <li><input type="submit" value="{% trans 'Save' %}" class="grp-button grp-default" name="_save" /></li>
         {% endif %}
         {% if show_save_as_new %}
-        	<li><input type="submit" value="{% trans 'Save as new' %}" class="grp-button" name="_saveasnew" {{ onclick_attrib }}/></li>
+            <li><input type="submit" value="{% trans 'Save as new' %}" class="grp-button" name="_saveasnew" /></li>
         {% endif %}
         {% if show_save_and_add_another %}
-        	<li><input type="submit" value="{% trans 'Save and add another' %}" class="grp-button" name="_addanother" {{ onclick_attrib }} /></li>
+            <li><input type="submit" value="{% trans 'Save and add another' %}" class="grp-button" name="_addanother" /></li>
         {% endif %}
         {% if show_save_and_continue %}
-        	<li><input type="submit" value="{% trans 'Save and continue editing' %}" class="grp-button" name="_continue" {{ onclick_attrib }}/></li>
+            <li><input type="submit" value="{% trans 'Save and continue editing' %}" class="grp-button" name="_continue" /></li>
         {% endif %}
     </ul>
 </footer>


### PR DESCRIPTION
This has been removed in Django 1.4-1693 (commit gd7b49f5).

When using TEMPLATE_STRING_IF_INVALID, this causes an error.
