### PR TITLE
Autocomplete helpers get_app_name() and get_model_name() remove empty st...

### DIFF
--- a/grappelli/static/grappelli/js/grappelli.js
+++ b/grappelli/static/grappelli/js/grappelli.js
@@ -149,7 +149,6 @@ var django = {
         var link = elem.next("a");
         if (link.length > 0) {
             var url = link.attr('href').split('/');
-            url = url.filter( function(part){ return part.length > 0 } );
             return url[url.length-1].replace('?', '');
         }
         return false;


### PR DESCRIPTION
...rings from the split URL parts list before extracting the relevant part.

This eliminates issues when using URLs with a trailing "/".

If you have an URL like:
"/admin/app_name/model_name/add/", before this fix, `get_app_name` would return "model_name" and `get_model_name` would return "add", because:

```
> "/admin/app_name/model_name/add/".split('/')
["", "admin", "app_name", "model_name", "add", ""]
```

This problem occurred with Grappelli 2.4.10, and Django 1.5.4.

**PLEASE NOTE:** I haven't supplied the minified version of the modified script, because I'm not sure what tool you use for minification on the project.  Can you please supply that information?  It will make it easier for me to contribute in future.
