### PR TITLE
Handle DoesNotExist error with switch_user_dropdown

### DIFF
--- a/grappelli/templatetags/grp_tags.py
+++ b/grappelli/templatetags/grp_tags.py
@@ -218,7 +218,10 @@ def switch_user_dropdown(context):
         tpl = get_template("admin/includes_grappelli/switch_user_dropdown.html")
         request = context["request"]
         session_user = request.session.get("original_user", {"id": request.user.id, "username": request.user.username})
-        original_user = User.objects.get(pk=session_user["id"], is_staff=True)
+        try:
+            original_user = User.objects.get(pk=session_user["id"], is_staff=True)
+        except User.DoesNotExist:
+            return ""
         if SWITCH_USER_ORIGINAL(original_user):
             object_list = [user for user in User.objects.filter(is_staff=True).exclude(pk=original_user.pk) if SWITCH_USER_TARGET(original_user, user)]
             return tpl.render(Context({


### PR DESCRIPTION
The user might not exist anymore. This can especially happen during
automatic (Selenium) tests.
