### PR TITLE
Fix "RuntimeError: App registry isn't ready yet." with collectstatic

### DIFF
--- a/grappelli/views/switch.py
+++ b/grappelli/views/switch.py
@@ -16,7 +16,7 @@ from django.contrib.admin.views.decorators import staff_member_required
 try:
     from django.contrib.auth import get_user_model
     User = get_user_model()
-except ImportError:
+except (ImportError, RuntimeError):
     from django.contrib.auth.models import User
 
 # GRAPPELLI IMPORTS


### PR DESCRIPTION
When invoking `collectstatic` on a Django 1.7 beta installation, the
following error arises:

>  File "venv/local/lib/python2.7/site-packages/debug_toolbar/models.py", line 63, in <module>
    patch_root_urlconf()
  File "venv/local/lib/python2.7/site-packages/debug_toolbar/models.py", line 51, in patch_root_urlconf
    reverse('djdt:render_panel')
  File "venv/src/django/django/core/urlresolvers.py", line 490, in reverse
    app_list = resolver.app_dict[ns]
  File "venv/src/django/django/core/urlresolvers.py", line 310, in app_dict
    self._populate()
  File "venv/src/django/django/core/urlresolvers.py", line 264, in _populate
    for pattern in reversed(self.url_patterns):
  File "venv/src/django/django/core/urlresolvers.py", line 348, in url_patterns
    patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
  File "venv/src/django/django/core/urlresolvers.py", line 342, in urlconf_module
    self._urlconf_module = import_module(self.urlconf_name)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/home/project/releases/master/project/config/urls.py", line 23, in <module>
    (r'^grappelli/', include('grappelli.urls')),
  File "venv/src/django/django/conf/urls/__init__.py", line 28, in include
    urlconf_module = import_module(urlconf_module)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "venv/src/django-grappelli-25x/grappelli/urls.py", line 12, in <module>
    from .views.switch import switch_user
  File "venv/src/django-grappelli-25x/grappelli/views/switch.py", line 18, in <module>
    User = get_user_model()
  File "venv/src/django/django/contrib/auth/__init__.py", line 129, in get_user_model
    return django_apps.get_model(settings.AUTH_USER_MODEL)
  File "venv/src/django/django/apps/registry.py", line 187, in get_model
    self.check_ready()
  File "venv/src/django/django/apps/registry.py", line 119, in check_ready
    raise RuntimeError("App registry isn't ready yet.")
RuntimeError: App registry isn't ready yet.

This should probably use settings.AUTH_USER_MODEL in any case / or as fallback, but I was not sure how to handle it (seeing that django.utils.importlib is marked for deprecation already).