### PR TITLE
Fix change_form peer-inside-peer blocks with extrahead and content

### DIFF
--- a/grappelli/templates/admin/change_form.html
+++ b/grappelli/templates/admin/change_form.html
@@ -100,6 +100,19 @@
     {{ media }}
 {% endblock %}
 
+{% block extrahead %}
+    {{ block.super }}
+    {% if adminform and add %}
+        <script type="text/javascript">
+            (function($){
+                $(document).ready(function() {
+                    $('form#{{ opts.model_name }}_form :input:visible:enabled:first').focus();
+                });
+            }(grp.jQuery));
+        </script>
+    {% endif %}
+{% endblock %}
+
 <!-- COLTYPE/BODYCLASS -->
 {% block bodyclass %}{{ opts.app_label }}-{{ opts.object_name.lower }} grp-change-form{% endblock %}
 {% block content-class %}{% endblock %}
@@ -176,20 +189,7 @@
             
             <!-- Submit-Row -->
             {% block submit_buttons_bottom %}{% submit_row %}{% endblock %}
-            
-            {% if adminform and add %}
-                {% block extrahead %}
-                    {{ block.super }}
-                    <script type="text/javascript">
-                        (function($){
-                            $(document).ready(function() {
-                                $('form#{{ opts.model_name }}_form :input:visible:enabled:first').focus()
-                            });
-                        }(grp.jQuery));
-                    </script>
-                {% endblock %}
-            {% endif %}
-            
+
             <!-- JS for prepopulated fields -->
             {% prepopulated_fields_js %}
             


### PR DESCRIPTION
Was getting duplication of anything added in `extrahead` in sub-templates with grappelli 2.4.6 and django 1.5.5 - and therefore javascript was executing twice.
