### PR TITLE
Fixed exception in exception cases

### DIFF
--- a/grappelli/views/related.py
+++ b/grappelli/views/related.py
@@ -104,7 +104,7 @@ class M2MLookup(RelatedLookup):
             try:
                 obj = self.get_queryset().get(pk=obj_id)
                 data.append({"value": obj_id, "label": get_label(obj)})
-            except (self.model.DoesNotExist, ValueError):
+            except:
                 data.append({"value": obj_id, "label": _("?")})
         return data
 


### PR DESCRIPTION
Fix a bug triggered when self.model is None : 

"AttributeError: 'NoneType' object has no attribute 'DoesNotExist'"
