### PR TITLE
app_index: use add_url instead of admin_url+"/add"

### DIFF
--- a/grappelli/templates/admin/app_index.html
+++ b/grappelli/templates/admin/app_index.html
@@ -27,7 +27,7 @@
                             {% if model.perms.change %}<a href="{{ model.admin_url }}"><strong>{{ model.name }}</strong></a>{% else %}<span><strong>{{ model.name }}</strong></span>{% endif %}
                             {% if model.perms.add or model.perms.change %}
                                 <ul class="grp-actions">
-                                    {% if model.perms.add %}<li class="grp-add-link"><a href="{{ model.admin_url }}add/">{% trans 'Add' %}</a></li>{% endif %}
+                                    {% if model.perms.add %}<li class="grp-add-link"><a href="{{ model.add_url }}">{% trans 'Add' %}</a></li>{% endif %}
                                     {% if model.perms.change %}<li class="grp-change-link"><a href="{{ model.admin_url }}">{% trans 'Change' %}</a></li>{% endif %}
                                 </ul>
                             {% endif %}


### PR DESCRIPTION
admin_url is not defined if the user has no change permissions, but is
allowed to add objects.

Django 1.6.5.

From Django's `contrib/admin/sites.py`:

```
if perms.get('change', False):
    try:
        model_dict['admin_url'] = reverse('admin:%s_%s_changelist' % info, current_app=self.name)
    except NoReverseMatch:
        pass
if perms.get('add', False):
    try:
        model_dict['add_url'] = reverse('admin:%s_%s_add' % info, current_app=self.name)
    except NoReverseMatch:
        pass
```
