### PR TITLE
Datepicker today button handler "hack" does not work

### DIFF
--- a/grappelli/static/grappelli/js/grappelli.js
+++ b/grappelli/static/grappelli/js/grappelli.js
@@ -65,7 +65,7 @@ var django = {
         // HACK: adds an event listener to the today button of datepicker
         // if clicked today gets selected and datepicker hides.
         // use on() because couldn't find hook after datepicker generates it's complete dom.
-        $(".ui-datepicker-current").on('click', function() {
+        $(document).on('click', '.ui-datepicker-current', function() {
             $.datepicker._selectDate(grappelli.datepicker_instance);
             grappelli.datepicker_instance = null;
         });


### PR DESCRIPTION
During init of datepicker, [these lines](https://github.com/sehmaschine/django-grappelli/blob/master/grappelli/static/grappelli/js/grappelli.js#L68-L71) add functionality that should handle clicks on "today" button by selecting and closing the widget.

Unfortunately this does not work with current selector, due to how jquery ui widget is "refreshed" (where button dom elements are destroyed and created again).

To solve this, I used a [delegated handler](http://learn.jquery.com/events/event-delegation/) like so:

```
$(document).on('click', '.ui-datepicker-current', function() {
    $.datepicker._selectDate(grappelli.datepicker_instance);
    grappelli.datepicker_instance = null;
});
```

This retains the handler for the generated buttons.
