### PR TITLE
Update utils.py

### DIFF
--- a/grappelli/dashboard/utils.py
+++ b/grappelli/dashboard/utils.py
@@ -11,7 +11,7 @@ from fnmatch import fnmatch
 from django.conf import settings
 from django.contrib import admin
 from django.core.urlresolvers import reverse
-from django.utils.importlib import import_module
+from importlib import import_module
 
 
 def _get_dashboard_cls(dashboard_cls, context):


### PR DESCRIPTION
Django.utils.importlib deprecated in next versions.
