### PR TITLE
Fixing javascript error in IE8 while selecting the item from autocomplete menu

### DIFF
--- a/grappelli/static/grappelli/js/jquery.grp_autocomplete_fk.js
+++ b/grappelli/static/grappelli/js/jquery.grp_autocomplete_fk.js
@@ -112,12 +112,12 @@
                 if (!item.value) {
                     return $("<li></li>")
                         .data( "item.autocomplete", item )
-                        .append( "<span class='error'>" + item.label)
+                        .append( "<span class='error'>" + item.label + "</span>")
                         .appendTo(ul);
                 } else {
                     return $("<li></li>")
                         .data( "item.autocomplete", item )
-                        .append( "<a>" + item.label)
+                        .append( "<a>" + item.label + "</a>")
                         .appendTo(ul);
                 }
             };

--- a/grappelli/static/grappelli/js/jquery.grp_autocomplete_generic.js
+++ b/grappelli/static/grappelli/js/jquery.grp_autocomplete_generic.js
@@ -147,12 +147,12 @@
                 if (!item.value) {
                     return $("<li></li>")
                         .data( "item.autocomplete", item )
-                        .append( "<span class='error'>" + item.label)
+                        .append( "<span class='error'>" + item.label + "</span>")
                         .appendTo(ul);
                 } else {
                     return $("<li></li>")
                         .data( "item.autocomplete", item )
-                        .append( "<a>" + item.label)
+                        .append( "<a>" + item.label + "</a>")
                         .appendTo(ul);
                 }
             };

--- a/grappelli/static/grappelli/js/jquery.grp_autocomplete_m2m.js
+++ b/grappelli/static/grappelli/js/jquery.grp_autocomplete_m2m.js
@@ -167,12 +167,12 @@
                 if (!item.value) {
                     return $("<li></li>")
                         .data( "item.autocomplete", item )
-                        .append( "<span class='error'>" + item.label)
+                        .append( "<span class='error'>" + item.label + "</span>")
                         .appendTo(ul);
                 } else {
                     return $("<li></li>")
                         .data( "item.autocomplete", item )
-                        .append( "<a>" + item.label)
+                        .append( "<a>" + item.label + "</a>")
                         .appendTo(ul);
                 }
             };


### PR DESCRIPTION
I've added enclosing tags to all _renderItem() JavaScript functions to fix wrapping item label with <a>, <span> tags. Forgetting to enclose labels properly ends up in not adding <a>, <span> tags at all in IE8 which eventually leads to a JavaScript error while trying to select rendered autocomplete item.
