### PR TITLE
add missing {% use admin_urls %}

### DIFF
--- a/grappelli/templates/admin/change_list_filter_sidebar.html
+++ b/grappelli/templates/admin/change_list_filter_sidebar.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 
 <!-- LOADING -->
-{% load admin_list i18n grp_tags %}
+{% load admin_list i18n grp_tags admin_urls %}
 
 <!-- STYLESHEETS -->
 {% block stylesheets %}


### PR DESCRIPTION
With Django 1.7c1 and dev/2.6.x, adding  `change_list_template = "admin/change_list_filter_sidebar.html"` to a ModelAdmin throws an `Invalid filter: 'admin_urlname'` error. 

This adds the missing `{% use admin_urls %}`.
