### PR TITLE
Fix bulk delete confirmation in Django 1.7

### DIFF
--- a/grappelli/templates/admin/delete_selected_confirmation.html
+++ b/grappelli/templates/admin/delete_selected_confirmation.html
@@ -11,7 +11,7 @@
 {% block breadcrumbs %}
     <ul class="grp-horizontal-list">
         <li><a href="{% url 'admin:index' %}">{% trans "Home" %}</a></li>
-        <li><a href="{% url 'admin:app_list' app_label=app_label %}">{% trans app_label|capfirst|escape %}</a></li>
+        <li><a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a></li>
         <li><a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst|escape }}</a></li>
         <li>{% trans 'Delete multiple objects' %}</li>
     </ul>


### PR DESCRIPTION
On Django 1.7 this template raises

```
Exception Type: NoReverseMatch at /admin/<app_label>/<model>/
Exception Value: Reverse for 'app_list' with arguments '()' and keyword arguments '{u'app_label': ''}' not found.
```
