### PR TITLE
Change 'formsetsort' template filter formset handling

### DIFF
--- a/grappelli/templatetags/grp_tags.py
+++ b/grappelli/templatetags/grp_tags.py
@@ -128,14 +128,12 @@ def formsetsort(formset, arg):
     if arg:
         sorted_list = []
         for item in formset:
-            position = item.form[arg].data
-            if position and position != "-1":
-                sorted_list.append((int(position), item))
+            if item.form.instance.pk:
+                sorted_list.append((item.form[arg].value(), item))
         sorted_list.sort()
         sorted_list = [item[1] for item in sorted_list]
         for item in formset:
-            position = item.form[arg].data
-            if not position or position == "-1":
+            if not item.form.instance.pk:
                 sorted_list.append(item)
     else:
         sorted_list = formset


### PR DESCRIPTION
VERSIONS: Grappelli master, Django 1.6.5
STATICFILES: OK
JAVASCRIPTS: OK
CUSTOMIZATIONS: NONE

Hi!

I have stumbled on a problem with  a 'formsetsort' filter. I've been trying to order inline instances of a model which does not in fact have any ordering field by using a custom modelform where this field is present and populated programmatically as a default field value.

This worked nicely overall except instnaces were displayed unordered after the page was refreshed.  
After some examination I found that 'formsetsort' filter was responsible for this.

I have a two improvements to suggest:  
1. instead of checking BoundField.data atribute, call .value() method. The former thechnique yields nothing for additional modelform fields until validaiton (not sure of exact point of time) occurs. This also eliminates str->int conversions since .value() takes care of that.  
2. tell forms bound to saved and new instances (extra inlines) apart by checking the presence of the instance primary key. No need to guess from ordering field content.

Regards,
Sergey.
