### PR TITLE
Use pk instead of id

### DIFF
--- a/grappelli/dashboard/modules.py
+++ b/grappelli/dashboard/modules.py
@@ -331,7 +331,7 @@ class RecentActions(DashboardModule):
         if request.user is None:
             qs = LogEntry.objects.all()
         else:
-            qs = LogEntry.objects.filter(user__id__exact=request.user.id)
+            qs = LogEntry.objects.filter(user__pk__exact=request.user.pk)
 
         if self.include_list:
             qs = qs.filter(get_qset(self.include_list))


### PR DESCRIPTION
Looks like this breaks user models which rely on specific primary keys.

I think using PK should work in all cases but I could have gotten the wrong end of the stick, but it works for me.
