### PR TITLE
Handled LookupError in RelatedLookup view

### DIFF
--- a/grappelli/views/related.py
+++ b/grappelli/views/related.py
@@ -46,7 +46,10 @@ class RelatedLookup(View):
         return 'object_id' in self.GET and 'app_label' in self.GET and 'model_name' in self.GET
 
     def get_model(self):
-        self.model = models.get_model(self.GET['app_label'], self.GET['model_name'])
+        try:
+            self.model = models.get_model(self.GET['app_label'], self.GET['model_name'])
+        except LookupError:
+            self.model = None
         return self.model
 
     def get_filtered_queryset(self, qs):


### PR DESCRIPTION
Calling the `RelatedLookup` with wrong `app_label` and `model_name` parameters curently raises a 500. 
Example: `/grappelli/lookup/related/?object_id=&app_label=false&model_name=false`

The pull request handles the error so that the view returns `[{"value": null, "label": ""}]` in this case.

