### PR TITLE
Fixed error when constance needs a hidden field

### DIFF
--- a/grappelli/templates/admin/constance/change_list.html
+++ b/grappelli/templates/admin/constance/change_list.html
@@ -51,6 +51,19 @@
 {% block content %}
     <form id="grp-changelist-form" action="" method="post">{% csrf_token %}
         <section id="grp-changelist" class="grp-editable">
+            {% if form.errors %}
+            <ul class="grp-messagelist">
+            {% endif %}
+            {% for field in form.hidden_fields %}
+                {% for error in field.errors %}
+                  <li class="grp-error">{{ error }}</li>
+                {% endfor %}
+                {{ field }}
+            {% endfor %}
+            {% if form.errors %}
+            </ul>
+            {% endif %}
+
             <header style="display:none"><h1>Results</h1></header>
                 <div class="grp-module grp-changelist-results">
                     <table id="result_list" cellspacing="0" class="grp-sortable">


### PR DESCRIPTION
Recently django-constance has added a way to prevent changes made by someone else at the same time, this requires to render a hidden field to validate it, you can see the change here:

https://github.com/jezdez/django-constance/blob/abd42df3046740e77a443acf479bdfb4e529b251/constance/templates/admin/constance/change_list.html#L40

![screen shot 2014-12-10 at 2 48 56 pm](https://cloud.githubusercontent.com/assets/202559/5384429/458b648c-8087-11e4-8400-7c0f7efc9d5d.png)

I have added the same code, using grappelli style to copy the same behavior.

It was very hard to find this was causing the problem, so I would recommend to find a way to remove this template override, it is very hard to find any issue, and also should be hard to keep up with the changes on the original library.

From what I saw this was created just to support the calendar widget, maybe there is a different approach to keep the same support without having to maintain a copy of the template here.

It would be very nice if you make a quick pypi release with this fix.

Thanks