### PR TITLE
Minor fixes in some templates

### DIFF
--- a/grappelli/dashboard/templates/grappelli/dashboard/modules/app_list.html
+++ b/grappelli/dashboard/templates/grappelli/dashboard/modules/app_list.html
@@ -3,7 +3,7 @@
 {% block module_content %}
     {% spaceless %}
     {% for child in module.children %}
-        <div class="grp-module" id="module-{{child.title|lower}}">
+        <div class="grp-module" id="module-{{child.name|lower}}">
             <h{% if subindex %}4{% else %}3{% endif %}><a href="{{ child.url }}">{% trans child.name %}</a></h{% if subindex %}4{% else %}3{% endif %}>
             {% for model in child.models %}
                 <div class="grp-row">

--- a/grappelli/templates/admin/auth/user/change_password.html
+++ b/grappelli/templates/admin/auth/user/change_password.html
@@ -7,7 +7,7 @@
             <li><a href="{% url 'admin:index' %}">{% trans "Home" %}</a></li>
             <li><a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a></li>
             <li><a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a></li>
-            <li><a href="{% url opts|admin_urlname:'changelist' %}{{ original.pk }}">{{ original|truncatewords:"18" }}</a></li>
+            <li><a href="{% url opts|admin_urlname:'change' original.pk|admin_urlquote%}">{{ original|truncatewords:"18" }}</a></li>
             <li>{% trans 'Change password' %}</li>
         </ul>
     {% endif %}


### PR DESCRIPTION
    Django version: 1.7.2
    Grappelli version: 2.6.4

Breadcrumb link for object’s change view (4th link) was created without trailing slash, so it caused some problems.
Changes are based on the original Django template `django/contrib/admin/templates/admin/auth/user/change_password.html` (line 16).

HTML attribute `id` was not generated correctly for the element `.grp-module` in the template `grappelli/dashboard/modules/app_list.html` because `child` has `name` instead of `title`.