### PR TITLE
use get_username to retrieve username, support custom user models

### DIFF
--- a/grappelli/templatetags/grp_tags.py
+++ b/grappelli/templatetags/grp_tags.py
@@ -226,7 +226,7 @@ def switch_user_dropdown(context):
     if SWITCH_USER:
         tpl = get_template("admin/includes_grappelli/switch_user_dropdown.html")
         request = context["request"]
-        session_user = request.session.get("original_user", {"id": request.user.id, "username": request.user.username})
+        session_user = request.session.get("original_user", {"id": request.user.id, "username": request.user.get_username()})
         try:
             original_user = User.objects.get(pk=session_user["id"], is_staff=True)
         except User.DoesNotExist:

--- a/grappelli/views/switch.py
+++ b/grappelli/views/switch.py
@@ -28,7 +28,7 @@ def switch_user(request, object_id):
 
     # current/session user
     current_user = request.user
-    session_user = request.session.get("original_user", {"id": current_user.id, "username": current_user.username})
+    session_user = request.session.get("original_user", {"id": current_user.id, "username": current_user.get_username()})
 
     # check original_user
     try:
@@ -63,6 +63,6 @@ def switch_user(request, object_id):
     if hasattr(target_user, 'backend'):
         login(request, target_user)
         if original_user.id != target_user.id:
-            request.session["original_user"] = {"id": original_user.id, "username": original_user.username}
+            request.session["original_user"] = {"id": original_user.id, "username": original_user.get_username()}
 
     return redirect(request.GET.get("redirect"))


### PR DESCRIPTION
VERSIONS: Grappelli 2.6.4.

If someone is using a custom user model and has a different username field (such as email) grappelli looks for the username field thus producing an error. There is a helper function in django called `get_username` for this.