### PR TITLE
fix issue with footer overlap when using GeoDjango

### DIFF
--- a/grappelli/compass/sass/screen.scss
+++ b/grappelli/compass/sass/screen.scss
@@ -522,7 +522,7 @@ body.grp-change-form #grp-content-container > form > div {
 
 @mixin grp-fixed-footer {
     position: fixed;
-    z-index: 900;
+    z-index: 1000;
     float: left;
     bottom: 0;
     left: 0;


### PR DESCRIPTION
![screen shot 2015-03-27 at 22 43 59](https://cloud.githubusercontent.com/assets/169394/6878276/1fe0d03c-d4d3-11e4-86b5-3af3b2b05b41.png)
