### PR TITLE
Fixed position of custom views in index.html, fixed #431

### DIFF
--- a/grappelli/templates/admin/index.html
+++ b/grappelli/templates/admin/index.html
@@ -58,19 +58,19 @@
             {% empty %}
                 <p>{% trans "You don´t have permission to edit anything." %}</p>
             {% endfor %}
-        </div>
-        {% block custom_views %}
-            {% if custom_list %}
-                <div class="grp-module" id="custom_views">
-                    <h2>{% trans 'Custom Views' %}</h2>
-                    <div class="grp-row">
-                        {% for path, name in custom_list %}
-                            <a href="{{ path }}"><strong>{{ name }}</strong></a>
-                        {% endfor %}
+            {% block custom_views %}
+                {% if custom_list %}
+                    <div class="grp-module" id="custom_views">
+                        <h2>{% trans 'Custom Views' %}</h2>
+                        <div class="grp-row">
+                            {% for path, name in custom_list %}
+                                <a href="{{ path }}"><strong>{{ name }}</strong></a>
+                            {% endfor %}
+                        </div>
                     </div>
-                </div>
-            {% endif %}
-        {% endblock %}
+                {% endif %}
+            {% endblock %}
+        </div>
         <div class="g-d-6 g-d-l">
             <div class="grp-module" id="grp-recent-actions-module">
                 <h2>{% trans 'Recent Actions' %}</h2>


### PR DESCRIPTION
Position of block isn't correct, it's out of `div.g-d-12.g-d-f` so it ruins style of admin page. This might not be a perfect solution but good enough for now.