### PR TITLE
Fix deprecation warning with django 1.8

### DIFF
--- a/grappelli/views/related.py
+++ b/grappelli/views/related.py
@@ -14,7 +14,10 @@ from django.views.generic import View
 from django.utils.translation import ungettext, ugettext as _
 from django.utils.encoding import smart_text
 from django.core.exceptions import PermissionDenied
-from django.contrib.admin.util import prepare_lookup_value
+try:
+    from django.contrib.admin.utils import prepare_lookup_value
+except ImportError:
+    from django.contrib.admin.util import prepare_lookup_value
 from django.core.serializers.json import DjangoJSONEncoder
 
 # GRAPPELLI IMPORTS


### PR DESCRIPTION
With django 1.8, I get this message: 
```RemovedInDjango19Warning: The django.contrib.admin.util module has been renamed. Use django.contrib.admin.utils instead.
  "Use django.contrib.admin.utils instead.", RemovedInDjango19Warning)```