### PR TITLE
Fix related object lookup popup

### DIFF
--- a/grappelli/static/admin/js/admin/RelatedObjectLookups.js
+++ b/grappelli/static/admin/js/admin/RelatedObjectLookups.js
@@ -27,19 +27,39 @@ function windowname_to_id(text) {
     return text;
 }
 
-function showRelatedObjectLookupPopup(triggeringLink) {
-    var name = triggeringLink.id.replace(/^lookup_/, '');
+/* new from 18 */
+function showAdminPopup(triggeringLink, name_regexp) {
+    var name = triggeringLink.id.replace(name_regexp, '');
     name = id_to_windowname(name);
-    var href;
-    if (triggeringLink.href.search(/\?/) >= 0) {
-        href = triggeringLink.href + '&_popup=1';
+    var href = triggeringLink.href;
+    if (href.indexOf('?') == -1) {
+        href += '?_popup=1';
     } else {
-        href = triggeringLink.href + '?_popup=1';
+        href  += '&_popup=1';
     }
-    // GRAPPELLI CUSTOM: changed width
-    var win = window.open(href, name, 'height=500,width=1000,resizable=yes,scrollbars=yes');
+    var win = window.open(href, name, 'height=500,width=800,resizable=yes,scrollbars=yes');
     win.focus();
     return false;
+}
+
+function showRelatedObjectLookupPopup(triggeringLink) {
+    /* grap */
+    // var name = triggeringLink.id.replace(/^lookup_/, '');
+    // name = id_to_windowname(name);
+    // var href;
+    // if (triggeringLink.href.search(/\?/) >= 0) {
+    //     href = triggeringLink.href + '&_popup=1';
+    // } else {
+    //     href = triggeringLink.href + '?_popup=1';
+    // }
+    // // GRAPPELLI CUSTOM: changed width
+    // var win = window.open(href, name, 'height=500,width=1000,resizable=yes,scrollbars=yes');
+    // win.focus();
+    // return false;
+    /* end grap */
+    /* 18 */
+    return showAdminPopup(triggeringLink, /^lookup_/);
+    /* end 18 */
 }
 
 function dismissRelatedLookupPopup(win, chosenId) {
@@ -63,7 +83,8 @@ function removeRelatedObject(triggeringLink) {
     elem.focus();
 }
 
-function showAddAnotherPopup(triggeringLink) {
+function showRelatedObjectPopup(triggeringLink) {
+    /* grap */
     var name = triggeringLink.id.replace(/^add_/, '');
     name = id_to_windowname(name);
     var href = triggeringLink.href;
@@ -76,9 +97,18 @@ function showAddAnotherPopup(triggeringLink) {
     var win = window.open(href, name, 'height=500,width=1000,resizable=yes,scrollbars=yes');
     win.focus();
     return false;
+    /* end grap */
+    /* 18 */
+    var name = triggeringLink.id.replace(/^(change|add|delete)_/, '');
+    name = id_to_windowname(name);
+    var href = triggeringLink.href;
+    var win = window.open(href, name, 'height=500,width=800,resizable=yes,scrollbars=yes');
+    win.focus();
+    return false;
+    /* end 18 */
 }
 
-function dismissAddAnotherPopup(win, newId, newRepr) {
+function dismissAddRelatedObjectPopup(win, newId, newRepr) {
     // newId and newRepr are expected to have previously been escaped by
     // django.utils.html.escape.
     newId = html_unescape(newId);
@@ -98,7 +128,12 @@ function dismissAddAnotherPopup(win, newId, newRepr) {
             } else {
                 elem.value = newId;
             }
+            /* grap */
             elem.focus();
+            /* end grap */
+            /* 18 */
+            django.jQuery(elem).trigger('change');
+            /* end 18 */
         }
     } else {
         var toId = name + "_to";
@@ -108,3 +143,35 @@ function dismissAddAnotherPopup(win, newId, newRepr) {
     }
     win.close();
 }
+
+/* from 18 */
+function dismissChangeRelatedObjectPopup(win, objId, newRepr, newId) {
+    objId = html_unescape(objId);
+    newRepr = html_unescape(newRepr);
+    var id = windowname_to_id(win.name).replace(/^edit_/, '');
+    var selectsSelector = interpolate('#%s, #%s_from, #%s_to', [id, id, id]);
+    var selects = django.jQuery(selectsSelector);
+    selects.find('option').each(function() {
+        if (this.value == objId) {
+            this.innerHTML = newRepr;
+            this.value = newId;
+        }
+    });
+    win.close();
+};
+
+function dismissDeleteRelatedObjectPopup(win, objId) {
+    objId = html_unescape(objId);
+    var id = windowname_to_id(win.name).replace(/^delete_/, '');
+    var selectsSelector = interpolate('#%s, #%s_from, #%s_to', [id, id, id]);
+    var selects = django.jQuery(selectsSelector);
+    selects.find('option').each(function() {
+        if (this.value == objId) {
+            django.jQuery(this).remove();
+        }
+    }).trigger('change');
+    win.close();
+};
+
+showAddAnotherPopup = showRelatedObjectPopup;
+dismissAddAnotherPopup = dismissAddRelatedObjectPopup;

--- a/grappelli/templates/admin/change_form.html
+++ b/grappelli/templates/admin/change_form.html
@@ -195,6 +195,26 @@
             <!-- Submit-Row -->
             {% block submit_buttons_bottom %}{% submit_row %}{% endblock %}
             
+            {% block admin_change_form_document_ready %}
+                <script type="text/javascript">
+                    (function($) {
+                        $(document).ready(function() {
+                            $('.add-another').click(function(e) {
+                                e.preventDefault();
+                                showAddAnotherPopup(this);
+                            });
+                            $('.related-lookup').click(function(e) {
+                                e.preventDefault();
+                                showRelatedObjectLookupPopup(this);
+                            });
+                        {% if adminform and add %}
+                            $('form#{{ opts.model_name }}_form :input:visible:enabled:first').focus()
+                        {% endif %}
+                        });
+                    })(django.jQuery);
+                </script>
+            {% endblock %}
+
             <!-- JS for prepopulated fields -->
             {% prepopulated_fields_js %}
             


### PR DESCRIPTION
Made this PR as a copy of #595 to base the commits on dev/2.7.x.

This is an attempt to fix #593 .
I'm trying to approach this in a number of steps1
1. Bring all the functions from `RelatedObjectLookups.js` in 1.8 into this repo
2. Get your comments on which functions can stay and which can go (elaboration below)
3. Finally fix the actual issue

More on 2. I've only been a user of grappelli, so I'm not too familiar with the piping that powers grappelli. Would like comments on the file itself to say which lines can stay and which lines can go. Note that the current pull request is ugly, has lots of comments saying if the code came from 1.8 `/* 18 */` or was originally there `/* grap */`. This is to help identify which portions of code came from where.
Eventually this PR can be squashed into a single commit to make the history cleaner.
Appreciate any comments, thanks!