### PR TITLE
Removed loading tags from future

### DIFF
--- a/grappelli/templates/admin/base.html
+++ b/grappelli/templates/admin/base.html
@@ -1,4 +1,4 @@
-{% load admin_static %}{% load firstof from future %}{% load i18n grp_tags %}
+{% load admin_static %}{% load i18n grp_tags %}
 <!DOCTYPE html>
 <html lang="{{ LANGUAGE_CODE|default:"en-us" }}" {% if LANGUAGE_BIDI %}dir="rtl"{% endif %}>
 <head>

--- a/grappelli/templates/admin/change_list_results.html
+++ b/grappelli/templates/admin/change_list_results.html
@@ -1,4 +1,3 @@
-{% load cycle from future %}
 {% load i18n admin_static %}
 {% if result_hidden_fields %}
     <div class="hiddenfields"> {# DIV for HTML validation #}

--- a/grappelli/templates/admin/constance/change_list.html
+++ b/grappelli/templates/admin/constance/change_list.html
@@ -1,7 +1,6 @@
 {% extends "admin/base_site.html" %}
 
 <!-- LOADING -->
-{% load cycle from future %}
 {% load admin_list i18n grp_tags admin_urls %}
 
 <!-- STYLESHEETS -->

--- a/grappelli/templates/admin/edit_inline/tabular.html
+++ b/grappelli/templates/admin/edit_inline/tabular.html
@@ -1,4 +1,3 @@
-{% load cycle from future %}
 {% load i18n grp_tags %}
 
 <!-- group -->

--- a/grappelli/templates/admin/includes_grappelli/switch_user_dropdown.html
+++ b/grappelli/templates/admin/includes_grappelli/switch_user_dropdown.html
@@ -1,4 +1,3 @@
-{% load firstof from future %}{% spaceless %}
 {% if request.session.original_user %}
     <li><a href="{% url 'grp_switch_user' request.session.original_user.id %}?redirect={{ request.path }}" class="grp-switch-user-is-original">{{ request.session.original_user.username }}</a></li>
 {% endif %}

--- a/grappelli/templates/grp_doc/change_form.html
+++ b/grappelli/templates/grp_doc/change_form.html
@@ -50,7 +50,6 @@
             <div class="g-d-24">
                 <div class="grp-doc-code"><pre><code>{% filter force_escape %}
 {% templatetag openblock %} extends "admin/base_site.html" {% templatetag closeblock %}
-{% templatetag openblock %} load url from future {% templatetag closeblock %}
 {% templatetag openblock %} load i18n admin_static admin_modify grp_tags {% templatetag closeblock %}
 {% templatetag openblock %} block bodyclass {% templatetag closeblock %}grp-change-form{% templatetag openblock %} endblock {% templatetag closeblock %}
 {% endfilter %}</code></pre></div>

--- a/grappelli/templates/grp_doc/change_list.html
+++ b/grappelli/templates/grp_doc/change_list.html
@@ -50,7 +50,6 @@
             <div class="g-d-24">
                 <div class="grp-doc-code"><pre><code>{% filter force_escape %}
 {% templatetag openblock %} extends "admin/base_site.html" {% templatetag closeblock %}
-{% templatetag openblock %} load url from future {% templatetag closeblock %}
 {% templatetag openblock %} load i18n admin_static admin_modify grp_tags {% templatetag closeblock %}
 {% templatetag openblock %} block bodyclass {% templatetag closeblock %}grp-change-list{% templatetag openblock %} endblock {% templatetag closeblock %}
 {% endfilter %}</code></pre></div>

--- a/grappelli/templates/smuggler/load_data_form.html
+++ b/grappelli/templates/smuggler/load_data_form.html
@@ -1,7 +1,6 @@
 {% extends "admin/base_site.html" %}
 
 <!-- LOADING -->
-{% load cycle from future %}
 {% load i18n admin_urls %}
 
 {% block title %}{% trans "Load data" %} {{ block.super }}{% endblock %}


### PR DESCRIPTION
This should be what is left of the RemovedInDjango19Warning(s) in issue #598.