### PR TITLE
Fix warning Django 1.8 module has been renamed.

### DIFF
--- a/grappelli/views/related.py
+++ b/grappelli/views/related.py
@@ -14,7 +14,7 @@ from django.views.generic import View
 from django.utils.translation import ungettext, ugettext as _
 from django.utils.encoding import smart_text
 from django.core.exceptions import PermissionDenied
-from django.contrib.admin.util import prepare_lookup_value
+from django.contrib.admin.utils import prepare_lookup_value
 from django.core.serializers.json import DjangoJSONEncoder
 
 # GRAPPELLI IMPORTS


### PR DESCRIPTION
Fix warning. 
warnings.warn(
    "The django.contrib.admin.util module has been renamed. "
    "Use django.contrib.admin.utils instead.", RemovedInDjango19Warning)