### PR TITLE
Preserve admin filters on object delete

### DIFF
--- a/grappelli/templates/admin/delete_confirmation.html
+++ b/grappelli/templates/admin/delete_confirmation.html
@@ -48,7 +48,8 @@
             <form action="" method="post">{% csrf_token %}
                 <div class="grp-module grp-submit-row grp-fixed-footer">
                     <ul>
-                        <li class="grp-float-left"><a href="../" class="grp-button grp-cancel-link">{% trans "Cancel" %}</a></li>
+                        {% url opts|admin_urlname:'change' object.pk|admin_urlquote as object_url %}
+                        <li class="grp-float-left"><a href="{% add_preserved_filters object_url %}" class="grp-button grp-cancel-link">{% trans "Cancel" %}</a></li>
                         <li><input type="submit" value="{% trans "Yes, I'm sure" %}" class="grp-button grp-default" /></li>
                     </ul>
                     <input type="hidden" name="post" value="yes" />

--- a/grappelli/templates/admin/submit_line.html
+++ b/grappelli/templates/admin/submit_line.html
@@ -1,9 +1,10 @@
-{% load i18n %}
+{% load i18n admin_urls %}
 <footer class="grp-module grp-submit-row grp-fixed-footer">
     <header style="display:none"><h1>Submit Options</h1></header>
     <ul>
         {% if show_delete_link %}
-            <li class="grp-float-left"><a href="delete/" class="grp-button grp-delete-link">{% trans "Delete" %}</a></li>
+            {% url opts|admin_urlname:'delete' original.pk|admin_urlquote as delete_url %}
+            <li class="grp-float-left"><a href="{% add_preserved_filters delete_url %}" class="grp-button grp-delete-link">{% trans "Delete" %}</a></li>
         {% endif %}
         {% if show_save %}
         	<li><input type="submit" value="{% trans 'Save' %}" class="grp-button grp-default" name="_save" /></li>


### PR DESCRIPTION
Preserve current filters when deleting an object in admin (including the cancel button). Was ported from [Django fix](https://github.com/django/django/commit/c86a9b63984f6692d478f6f70e3c78de4ec41814#diff-75c7039c514bc8378b82be100e1b586c) in 1.6.