### PR TITLE
sortable_field_name similar to foregin key name

### DIFF
--- a/grappelli/templates/admin/edit_inline/stacked.html
+++ b/grappelli/templates/admin/edit_inline/stacked.html
@@ -263,7 +263,7 @@
                     }
                 });
                 if (submit_values) {
-                    $(this).find("input[name$='"+sortable_field_name+"']").val(i);
+                    $(this).find("input[name$='-"+sortable_field_name+"']").val(i);
                     i++;
                 }
             });


### PR DESCRIPTION
This litle addition `-` prevent to find other field than `sortable_field_name`.
For example I have foreign key name like: lesson (input name like: lessonblock_set-4-lesson) and `sortable_field_name` is `n`, so `$(this).find("input[name$='"+sortable_field_name+"']").val(i);` change sortable ordering and foreign key to.