### PR TITLE
Remvoing RemovedInDjango19 deprecation warning for importlib

### DIFF
--- a/grappelli/dashboard/registry.py
+++ b/grappelli/dashboard/registry.py
@@ -33,7 +33,7 @@ def autodiscover(blacklist=[]):
     """
     import imp
     from django.conf import settings
-    from django.utils.importlib import import_module
+    from importlib import import_module
 
     blacklist.append('grappelli')
     blacklist.append('grappelli.dashboard')


### PR DESCRIPTION
`django.importlib` will be removed in Django 1.9, Django 1.8 shows a deprecation warning. 
Instead use stlib's importlib.