### PR TITLE
Allow Autocomplete lookups in tables with PostgreSQL json fields

### DIFF
--- a/grappelli/views/related.py
+++ b/grappelli/views/related.py
@@ -150,7 +150,7 @@ class AutocompleteLookup(RelatedLookup):
         qs = self.get_filtered_queryset(qs)
         qs = self.get_searched_queryset(qs)
         if connection.vendor == 'postgresql':
-            distinct_columns = self.model._meta.ordering + [self.model._meta.pk.column]
+            distinct_columns = list(self.model._meta.ordering) + [self.model._meta.pk.column]
             return qs.order_by(*distinct_columns).distinct(*distinct_columns)
         else:
             return qs.distinct()

--- a/grappelli/views/related.py
+++ b/grappelli/views/related.py
@@ -7,7 +7,7 @@ from functools import reduce
 
 # DJANGO IMPORTS
 from django.http import HttpResponse
-from django.db import models
+from django.db import models, connection
 from django.db.models.query import QuerySet
 from django.views.decorators.cache import never_cache
 from django.views.generic import View
@@ -149,7 +149,11 @@ class AutocompleteLookup(RelatedLookup):
         qs = super(AutocompleteLookup, self).get_queryset()
         qs = self.get_filtered_queryset(qs)
         qs = self.get_searched_queryset(qs)
-        return qs.distinct(self.model._meta.pk.column)
+        if connection.vendor == 'postgresql':
+            distinct_columns = self.model._meta.ordering + [self.model._meta.pk.column]
+            return qs.order_by(*distinct_columns).distinct(*distinct_columns)
+        else:
+            return qs.distinct()
 
     def get_data(self):
         return [{"value": f.pk, "label": get_label(f)} for f in self.get_queryset()[:AUTOCOMPLETE_LIMIT]]

--- a/grappelli/views/related.py
+++ b/grappelli/views/related.py
@@ -149,7 +149,7 @@ class AutocompleteLookup(RelatedLookup):
         qs = super(AutocompleteLookup, self).get_queryset()
         qs = self.get_filtered_queryset(qs)
         qs = self.get_searched_queryset(qs)
-        return qs.distinct()
+        return qs.distinct(self.model._meta.pk.column)
 
     def get_data(self):
         return [{"value": f.pk, "label": get_label(f)} for f in self.get_queryset()[:AUTOCOMPLETE_LIMIT]]


### PR DESCRIPTION
The json type in PostgreSQL doesn't have an equality operator, thus it will fail when querying with DISTINCT on all fields. This patch overcomes this limitation by restricting the DISTINCT to fields in ORDER BY + primary key.