### PR TITLE
Fix generating of autocomplete urls if add link url contains a query

### DIFF
--- a/grappelli/static/grappelli/js/grappelli.js
+++ b/grappelli/static/grappelli/js/grappelli.js
@@ -148,7 +148,7 @@ var inputTypes = [
     grappelli.get_app_label = function(elem) {
         var link = elem.next("a");
         if (link.length > 0) {
-            var url = link.attr('href').split('/');
+            var url = link.attr('href').split('?')[0].split('/');
             return url[url.length-3];
         }
         return false;
@@ -156,7 +156,7 @@ var inputTypes = [
     grappelli.get_model_name = function(elem) {
         var link = elem.next("a");
         if (link.length > 0) {
-            var url = link.attr('href').split('/');
+            var url = link.attr('href').split('?')[0].split('/');
             return url[url.length-2];
         }
         return false;


### PR DESCRIPTION
If the add link besides the input you use the autocomplete on contains a querystring, eg

    http://localhost:8000/admin/articles/article/add/?_to_field=publishable_ptr

(which happens if the related model uses model inheritance) the JS generates a wrong URL for calling the autocomplete: ` /grappelli/lookup/autocomplete/?term=art&app_label=article&model_name=add&query_string=_to_field=publishable_ptr` in this example....

Stripping the querystring in `grappelli.get_app_label` and `grappelli.get_model_name` should solve this... 