### PR TITLE
Add a check for autocomplete_search_fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ django_grappelli.egg-info/*
 grappelli/compass/.sass-cache/
 grappelli/static/tinymce_dev
 fabfile.py
+.cache
 .sass-cache
 .project
 .pydevproject

--- a/grappelli/__init__.py
+++ b/grappelli/__init__.py
@@ -1,1 +1,3 @@
 VERSION = '2.8.1'
+
+default_app_config = 'grappelli.apps.GrappelliConfig'

--- a/grappelli/apps.py
+++ b/grappelli/apps.py
@@ -1,0 +1,12 @@
+# coding: utf-8
+
+# DJANGO IMPORTS
+from django.apps import AppConfig
+
+
+class GrappelliConfig(AppConfig):
+    name = 'grappelli'
+
+    def ready(self):
+        from .checks import register_checks
+        register_checks()

--- a/grappelli/checks.py
+++ b/grappelli/checks.py
@@ -1,0 +1,62 @@
+# coding: utf-8
+
+# DJANGO IMPORTS
+from django.apps import apps
+from django.core.checks import Error, Tags, register
+from django.core.exceptions import FieldError
+from django.db.models import F
+
+
+def register_checks():
+    register(Tags.models)(check_models)
+
+
+def check_models(app_configs, **kwargs):
+    if app_configs is None:
+        app_configs = apps.get_app_configs()
+
+    errors = []
+    for app_config in app_configs:
+        for model in app_config.get_models():
+            errors.extend(check_model(model))
+    return errors
+
+
+def check_model(model):
+    errors = []
+    errors.extend(_check_autocomplete_search_fields(model))
+    return errors
+
+
+def _check_autocomplete_search_fields(model):
+    if not hasattr(model, 'autocomplete_search_fields'):
+        return []
+
+    # Ensure that autocomplete_search_fields returns a valid list of filters
+    # for a QuerySet on that model
+    failures = []
+    for lookup in model.autocomplete_search_fields():
+        try:
+            # This only constructs the QuerySet and doesn't actually query the
+            # DB, so it's fine for check phase.
+            model._default_manager.filter(**{lookup: F('pk')})
+        except FieldError:
+            failures.append(lookup)
+
+    if not failures:
+        return []
+    else:
+        return [
+            Error(
+                "Model {app}.{model} returned bad entries for "
+                "autocomplete_search_fields: {failures}".format(
+                    app=model._meta.app_label,
+                    model=model._meta.model_name,
+                    failures=",".join(failures)
+                ),
+                hint="A QuerySet for {model} could not be constructed. Fix "
+                     "the autocomplete_search_fields on it to return valid "
+                     "lookups.",
+                id='grappelli.E001'
+            )
+        ]

--- a/grappelli/tests/test_checks.py
+++ b/grappelli/tests/test_checks.py
@@ -1,0 +1,41 @@
+# coding: utf-8
+
+# DJANGO IMPORTS
+from django.core.management import call_command
+from django.test import TestCase
+
+# GRAPPELLI IMPORTS
+from grappelli.checks import check_model
+from grappelli.tests.models import Entry
+
+
+class ChecksTests(TestCase):
+
+    def test_run_checks(self):
+        # pytest-django doesn't run checks, but we should
+        call_command('check')
+
+
+class AutocompleteSearchFieldsChecksTests(TestCase):
+
+    def test_passes_for_Entry(self):
+        # Not strictly necessary as the check will run as part of the above
+        assert check_model(Entry) == []
+
+    def test_fails_for_Entry_broken_field_name(self):
+        @staticmethod
+        def broken():
+            return ("tytle__icontains",)
+
+        orig = Entry.__dict__['autocomplete_search_fields']
+        try:
+            Entry.autocomplete_search_fields = broken
+            errors = check_model(Entry)
+            assert len(errors) == 1
+            assert (
+                errors[0].msg ==
+                'Model grappelli.entry returned bad entries for '
+                'autocomplete_search_fields: tytle__icontains'
+            )
+        finally:
+            Entry.autocomplete_search_fields = orig

--- a/grappelli/tests/test_related.py
+++ b/grappelli/tests/test_related.py
@@ -21,7 +21,6 @@ from grappelli.tests.models import Category, Entry
 
 @override_settings(GRAPPELLI_AUTOCOMPLETE_LIMIT=10)
 @override_settings(GRAPPELLI_AUTOCOMPLETE_SEARCH_FIELDS={})
-@override_settings(ROOT_URLCONF="grappelli.tests.urls")
 class RelatedTests(TestCase):
 
     def setUp(self):

--- a/grappelli/tests/test_switch.py
+++ b/grappelli/tests/test_switch.py
@@ -17,7 +17,6 @@ from grappelli.templatetags.grp_tags import switch_user_dropdown
 @override_settings(GRAPPELLI_SWITCH_USER=True)
 @override_settings(GRAPPELLI_SWITCH_USER_ORIGINAL=lambda user: user.is_superuser)
 @override_settings(GRAPPELLI_SWITCH_USER_TARGET=lambda original_user, user: user.is_staff and not user.is_superuser)
-@override_settings(ROOT_URLCONF="grappelli.tests.urls")
 class SwitchTests(TestCase):
 
     def setUp(self):

--- a/requirements/requirements-testing.txt
+++ b/requirements/requirements-testing.txt
@@ -1,3 +1,4 @@
-py==1.4.27
-pytest-django==2.8.0
-pytest==2.7.1
+Django>=1.9,<1.10
+py==1.4.31
+pytest-django==2.9.1
+pytest==2.9.0

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -36,7 +36,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.security.SecurityMiddleware',
 )
 
-ROOT_URLCONF = 'urls'
+ROOT_URLCONF = 'grappelli.tests.urls'
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'
 USE_I18N = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,8 @@
 [tox]
-envlist = py{27,34,35}-django18
+envlist = py{27,34,35}
 
 [testenv]
 setenv =
     PYTHONDONTWRITEBYTECODE=1
-deps =
-    django18: Django>=1.9,<1.10
-    -rrequirements/requirements-testing.txt
-    coverage
+deps = -rrequirements/requirements-testing.txt
 commands = ./runtests.py {posargs}


### PR DESCRIPTION
We had a few errors that only turned up in production from typos in `autocomplete_search_fields`. This isn't hard to verify with a system check.

This PR includes my _first steps_ towards adding the check - the code is adapted from the working version in my project. It adds a grappellii [AppConfig](https://docs.djangoproject.com/en/1.8/ref/applications/) which registers the [checks](https://docs.djangoproject.com/en/1.8/topics/checks/) at the appropriate `ready()` signal . However it is incomplete, e.g. it doesn't use the autocomplete fields from `settings`.

I've basically hit the hurdle of not being able to run the tests I'm adding - I can't find any guide nor any obvious 'run tests' script.
