### PR TITLE
Add 'runtests' command, tox.ini, and fix all but one of the tests for Python 3

### DIFF
--- a/requirements/requirements-testing.txt
+++ b/requirements/requirements-testing.txt
@@ -1,0 +1,3 @@
+py==1.4.27
+pytest-django==2.8.0
+pytest==2.7.1

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+import os
+import sys
+
+import pytest
+
+
+def main():
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+    sys.path.insert(0, "test_project")
+    return pytest.main()
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author='Patrick Kranzlmueller, Axel Swoboda (vonautomatisch)',
     author_email='office@vonautomatisch.at',
     license='BSD',
-    packages=find_packages(),
+    packages=find_packages(exclude=['test_project']),
     include_package_data=True,
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -1,0 +1,63 @@
+# -*- coding:utf-8 -*-
+import os
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+DEBUG = True
+TEMPLATE_DEBUG = DEBUG
+
+SECRET_KEY = 'TOTALLYeeNOTeeSECRETeeeeeeeeeeeeeeeee472!bgs$0!i3k4'
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3'
+    },
+}
+
+ALLOWED_HOSTS = []
+
+INSTALLED_APPS = (
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'grappelli',
+)
+
+MIDDLEWARE_CLASSES = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django.middleware.security.SecurityMiddleware',
+)
+
+ROOT_URLCONF = 'urls'
+LANGUAGE_CODE = 'en-us'
+TIME_ZONE = 'UTC'
+USE_I18N = True
+USE_L10N = True
+STATIC_URL = '/static/'
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
+# Our settings
+GRAPPELLI_SWITCH_USER = True

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py{27,34}-django18
+
+[testenv]
+setenv =
+    PYTHONDONTWRITEBYTECODE=1
+deps =
+    django18: Django>=1.8,<1.9
+    -rrequirements/requirements-testing.txt
+    coverage
+commands = ./runtests.py {posargs}


### PR DESCRIPTION
As per #655 I was finding it hard to run the tests. `manage.py test grappelli` doesn't work on my current Django project due to a specialized test environment, so I was left without an environment to run the tests in. Thus I set up this `runtests` script that uses `pytest-django`, and includes a `tox.ini` to run the tests on Django 1.8, Python 2.7 and 3.4.

One test remains broken on Python 3.4, and I'm not sure why. It's near the section labelled `# FIXME: this should fail, because the custom admin queryset` so I don't know exactly what's up.