### PR TITLE
fetch language code and bidi

### DIFF
--- a/grappelli/templates/admin/base.html
+++ b/grappelli/templates/admin/base.html
@@ -1,5 +1,6 @@
 {% load admin_static %}{% load i18n grp_tags %}
 <!DOCTYPE html>
+{% get_current_language as LANGUAGE_CODE %}{% get_current_language_bidi as LANGUAGE_BIDI %}
 <html lang="{{ LANGUAGE_CODE|default:"en-us" }}" {% if LANGUAGE_BIDI %}dir="rtl"{% endif %}>
 <head>
     <title>{% block title %}{% endblock %}</title>


### PR DESCRIPTION
Fetch the LANGUAGE_CODE and LANGUAGE_BIDI before attempting to use them. I noticed this because I have 

```
class InvalidString(str):
    def __mod__(self, other):
        from django.template.base import TemplateSyntaxError
        raise TemplateSyntaxError(
            "Undefined variable or unknown value for: \"%s\"" % other)
```
as my `TEMPLATE_STRING_IF_INVALID`. The change is copied from the `admin/base.html` template from `django.contrib.admin`