### PR TITLE
Changed django-reversion templates to work with django-reversion>=1.9.3

### DIFF
--- a/grappelli/templates/reversion/recover_form.html
+++ b/grappelli/templates/reversion/recover_form.html
@@ -13,8 +13,13 @@
     {% endif %}
 {% endblock %}
 
+{% block object-tools %}{% endblock %}
+
 {% block form_top %}
     <div class="grp-rte">
         <p>{% blocktrans %}Press the save button below to recover this version of the object.{% endblocktrans %}</p>
     </div>
 {% endblock %}
+
+{% block submit_buttons_top %}{% with is_popup=1 %}{{block.super}}{% endwith %}{% endblock %}
+{% block submit_buttons_bottom %}{% with is_popup=1 %}{{block.super}}{% endwith %}{% endblock %}

--- a/grappelli/templates/reversion/revision_form.html
+++ b/grappelli/templates/reversion/revision_form.html
@@ -16,14 +16,11 @@
 
 {% block object-tools %}{% endblock%}
 
-{% block content %}
-    {% with 1 as is_popup %}
-        {{ block.super }}
-    {% endwith %}
-{% endblock %}
-
 {% block form_top %}
     <div class="grp-rte">
         <p>{% blocktrans %}Press the save button below to revert to this version of the object.{% endblocktrans %}</p>
     </div>
 {% endblock %}
+
+{% block submit_buttons_top %}{% with is_popup=1 %}{{block.super}}{% endwith %}{% endblock %}
+{% block submit_buttons_bottom %}{% with is_popup=1 %}{{block.super}}{% endwith %}{% endblock %}


### PR DESCRIPTION
Author of django-reversion here!

With the release of django-reversion 1.9.x, a couple of tweaks need to be made to your customized reversion templates. This was first noticed by a user in issue etianen/django-reversion#445

Hope this helps. :)