### PR TITLE
Fix Dashboard Media Class

### DIFF
--- a/grappelli/dashboard/dashboards.py
+++ b/grappelli/dashboard/dashboards.py
@@ -5,6 +5,7 @@ Module where grappelli dashboard classes are defined.
 """
 
 # DJANGO IMPORTS
+from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 from django.core.urlresolvers import reverse
 from django import forms
@@ -14,7 +15,7 @@ from grappelli.dashboard import modules
 from grappelli.dashboard.utils import get_admin_site_name
 
 
-class Dashboard(object):
+class Dashboard(six.with_metaclass(forms.MediaDefiningClass)):
     """
     Base class for dashboards.
     The Dashboard class is a simple python list that has three additional
@@ -85,13 +86,6 @@ class Dashboard(object):
                 ))
 
     """
-
-    # Using Django's Media meta class
-    __metaclass__ = forms.MediaDefiningClass
-
-    def _media(self):
-        return forms.Media()
-    media = property(_media)
 
     title = _('Dashboard')
     template = 'grappelli/dashboard/dashboard.html'


### PR DESCRIPTION
Currently, this code doesn't work:

```python
class CustomIndexDashboard(Dashboard):
    class Media:
        css = {'all': ['style.css']}
```

This is easily fixed by having `Dashboard` subclass `MediaDefiningClass` like [Django does](https://github.com/django/django/blob/1d8eb0cae57731b481a88dca272b2cb0d645bd8e/django/forms/widgets.py#L179). This makes defining `__metaclass__` or an empty `media` property unnecessary.