### PR TITLE
Strip descending order marks from distinct columns in autocomplete on PostgreSQL

### DIFF
--- a/grappelli/views/related.py
+++ b/grappelli/views/related.py
@@ -161,8 +161,9 @@ class AutocompleteLookup(RelatedLookup):
         qs = self.get_filtered_queryset(qs)
         qs = self.get_searched_queryset(qs)
         if connection.vendor == 'postgresql':
-            distinct_columns = list(self.model._meta.ordering) + [self.model._meta.pk.column]
-            return qs.order_by(*distinct_columns).distinct(*distinct_columns)
+            ordering = list(self.model._meta.ordering)
+            distinct_columns = [o.lstrip('-') for o in ordering] + [self.model._meta.pk.column]
+            return qs.order_by(*ordering).distinct(*distinct_columns)
         else:
             return qs.distinct()
 


### PR DESCRIPTION
Some models may have descending columns in their default ordering (like `('-date',)`), which makes autocomplete break because we're sticking the column names with the minus marks into `.distinct()`.