### PR TITLE
Fix Deprecation warning in Django 1.9

### DIFF
--- a/grappelli/urls.py
+++ b/grappelli/urls.py
@@ -1,16 +1,14 @@
 # coding: utf-8
 
 # DJANGO IMPORTS
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 # GRAPPELLI IMPORTS
 from .views.related import RelatedLookup, M2MLookup, AutocompleteLookup
 from .views.switch import switch_user
 
 
-urlpatterns = patterns(
-    '',
-
+urlpatterns = [
     # FOREIGNKEY & GENERIC LOOKUP
     url(r'^lookup/related/$', RelatedLookup.as_view(), name="grp_related_lookup"),
     url(r'^lookup/m2m/$', M2MLookup.as_view(), name="grp_m2m_lookup"),
@@ -53,4 +51,4 @@ urlpatterns = patterns(
 
     # url(r'^grp-doc', TemplateView.as_view(template_name='grp_doc/index.html'), name="grp_doc"),
 
-)
+]


### PR DESCRIPTION
Just upgraded to django 1.9, gives me these warnings:

`
[...]/local/lib/python2.7/site-packages/grappelli/urls.py:20: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
  url(r'^switch/user/(?P<object_id>\d+)/$', switch_user, name="grp_switch_user"),
`
This should fix that.