### PR TITLE
Fix CONSTANCE 1.1.1 compatibility

### DIFF
--- a/grappelli/templates/admin/constance/change_list.html
+++ b/grappelli/templates/admin/constance/change_list.html
@@ -88,7 +88,7 @@
                             </tr>
                         </thead>
                     </tbody>
-                    {% for item in config %}
+                    {% for item in config_values %}
                         <tr class="grp-row {% cycle 'grp-row-even' 'grp-row-odd' %}">
                             <td>
                                 <div class="grp-text"><strong>{{ item.name }}</strong></div>


### PR DESCRIPTION
Constance 1.1.1,  Django 1.8.5

Constance compatibility with grappelli was broken, there was a mismatch with the template variables used on django-constance :  
https://github.com/jezdez/django-constance/blob/master/constance/templates/admin/constance/change_list.html#L63