### PR TITLE
Django 1.9 fix

### DIFF
--- a/grappelli/dashboard/modules.py
+++ b/grappelli/dashboard/modules.py
@@ -6,7 +6,6 @@ Module where grappelli dashboard modules classes are defined.
 
 # DJANGO IMPORTS
 from django.utils.text import capfirst
-from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import ugettext_lazy as _
 from django.apps import apps as django_apps
 
@@ -309,6 +308,7 @@ class RecentActions(DashboardModule):
         request = context['request']
 
         def get_qset(list):
+            from django.contrib.contenttypes.models import ContentType
             qset = None
             for contenttype in list:
                 if isinstance(contenttype, ContentType):


### PR DESCRIPTION
Fixes "django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet."