### PR TITLE
Fixes autocomplete when ordering contains a simple foreign key mention.

### DIFF
--- a/grappelli/views/related.py
+++ b/grappelli/views/related.py
@@ -8,6 +8,7 @@ from functools import reduce
 # DJANGO IMPORTS
 from django.http import HttpResponse
 from django.db import models, connection
+from django.db.models.constants import LOOKUP_SEP
 from django.db.models.query import QuerySet
 from django.views.decorators.cache import never_cache
 from django.views.generic import View
@@ -181,12 +182,12 @@ class AutocompleteLookup(RelatedLookup):
         ordering = []
         for lookup in model._meta.ordering:
             opts = model._meta
-            for part in lookup.lstrip('-').split('__'):
+            for part in lookup.lstrip('-').split(LOOKUP_SEP):
                 field = opts.get_field(part)
                 if field.is_relation:
                     opts = field.rel.to._meta
             if previous_lookup_parts is not None:
-                lookup = previous_lookup_parts + '__' + lookup
+                lookup = previous_lookup_parts + LOOKUP_SEP + lookup
             if field.is_relation:
                 ordering.extend(self.get_final_ordering(opts.model, lookup))
             else:


### PR DESCRIPTION
Autocomplete is broken on my projects since #646 was merged. I get this exception on models with a related lookup in their `ordering` meta option: `django.db.utils.ProgrammingError: ERROR: SELECT DISTINCT ON expressions must match initial ORDER BY expressions`.

Minimal modelisation to reproduce the issue:

```python
from django.db.models import *

class BookType(Model):
    name = CharField(max_length=50)

    class Meta:
        ordering = ['name']

class Book(Model):
    name = CharField(max_length=50)
    type = ForeignKey(BookType)

    class Meta:
        ordering = ['type', 'name']
```

This is due to the difference between how the ORM interprets a relation lookup in `order_by` and in `distinct`. If I ask for `Book.objects.order_by('type')`, the ORM will interpret it as `Book.objects.order_by('type__name')` while it will interpret `Book.objects.distinct('type')` as `Book.objects.distinct('type_id')`. This is a good behaviour in my opinion, so there’s no inconsistency to report to the Django team. But in our case, it creates heterogeneous `distinct`/`order_by` SQL queries when we ask for homogeneity.

You can see in [these lines of the ORM](https://github.com/django/django/blob/53ccffdb8c8e47a4d4304df453d8c79a9be295ab/django/db/models/sql/compiler.py#L547-L577) how Django fetches the related orderings. Unfortunately, we can’t use this because it returns less than what we need. We therefore have to implement our own version of this algorithm, which I did in this pull request.