### PR TITLE
Use model's queryset when constructing search query

### DIFF
--- a/grappelli/views/related.py
+++ b/grappelli/views/related.py
@@ -147,12 +147,15 @@ class AutocompleteLookup(RelatedLookup):
 
         search_fields = get_autocomplete_search_fields(self.model)
         if search_fields:
+            search = models.Q()
             for word in term.split():
-                search = [models.Q(**{smart_text(item): smart_text(word)}) for item in search_fields]
-                search_qs = QuerySet(model)
-                search_qs.query.select_related = qs.query.select_related
-                search_qs = search_qs.filter(reduce(operator.or_, search))
-                qs &= search_qs
+                term_query = models.Q()
+                for search_field in search_fields:
+                    term_query |= models.Q(
+                        **{smart_text(search_field): smart_text(word)}
+                    )
+                search &= term_query
+            qs = qs.filter(search)
         else:
             qs = model.objects.none()
         return qs


### PR DESCRIPTION
We use `django-modeltranslation` who does magic work to rewrite lookups in queries to use language-specific fields. Seems that current way of constructing query does not play well with it (and use obscure merge-querysets feature).
This patch refactors `get_searched_queryset` to use only Q-objects to construct query
