### PR TITLE
Disabled import of url from future to prevent Django 1.9 crash

### DIFF
--- a/grappelli/templates/smuggler/load_data_form.html
+++ b/grappelli/templates/smuggler/load_data_form.html
@@ -2,7 +2,7 @@
 
 <!-- LOADING -->
 {# load cycle from future # cannot do this yet because we support Django < 1.6 #}
-{% load url from future %} {# For Django < 1.5 #}
+{# load url from future # cannot do this because Django 1.9 crashes #}
 {% load i18n admin_urls %}
 
 {% block title %}{% trans "Load data" %} {{ block.super }}{% endblock %}


### PR DESCRIPTION
With current version we have a silent crash on the template in Django 1.9 with the message:

Invalid template /usr/local/lib/python2.7/dist-packages/grappelli/templates/smuggler/load_data_form.html: 'url' is not a valid tag or filter in tag library 'future'

While 2.8.x branch is for Djang 1.9 only -- it should be fine.