### PR TITLE
Release as a universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
 [bdist_wheel]
 universal=1
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
By releasing as a [Python wheel](http://pythonwheels.com/) as well as a source distribution, you can speed up end user’s installs. After merging this command, to release you just need to run `python setup.py clean sdist bdist_wheel upload`.