### PR TITLE
Fix Gruntfile for changes in jshint

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,6 +11,7 @@ module.exports = function(grunt) {
       options: {
         "expr": true,
         "scripturl": true,
+        reporterOutput: "",
       },
       beforeconcat: ['grappelli/static/grappelli/js/grappelli.js', 'grappelli/static/grappelli/js/jquery*.js'],
       afterconcat: ['grappelli/static/grappelli/js/grappelli.min.js']


### PR DESCRIPTION
After a fresh install I got:

```
$ node_modules/.bin/grunt javascripts
Running "javascripts" task

Running "concat:dist" (concat) task
File grappelli/static/grappelli/js/grappelli.min.js created.

Running "jshint:afterconcat" (jshint) task
Warning: Path must be a string. Received null Use --force to continue.

Aborted due to warnings.
```

This is a known issue, with this fix: https://github.com/jshint/jshint/issues/2922#issuecomment-219263558