### PR TITLE
Replace action.change_message by new action.get_change_message

### DIFF
--- a/grappelli/templates/admin/object_history.html
+++ b/grappelli/templates/admin/object_history.html
@@ -33,7 +33,7 @@
                         <tr>
                             <th scope="grp-row">{{ action.action_time|date:_("DATETIME_FORMAT") }}</th>
                             <td>{{ action.user.username }}{% if action.user.get_full_name %} ({{ action.user.get_full_name }}){% endif %}</td>
-                            <td>{{ action.change_message }}</td>
+                            <td>{{ action.get_change_message }}</td>
                         </tr>
                     {% endfor %}
                 </tbody>


### PR DESCRIPTION
From https://docs.djangoproject.com/en/1.10/releases/1.10/#minor-features

> The LogEntry model now stores change messages in a JSON structure so that the message can be dynamically translated using the current active language. A new LogEntry.get_change_message() method is now the preferred way of retrieving the change message.

Django template: https://github.com/django/django/blob/master/django/contrib/admin/templates/admin/object_history.html#L32
Related Django changelog: https://github.com/django/django/commit/cf7894be88f6c27680ef80796b883f6e3b709b8b