### PR TITLE
Django 1.11 compatibility

### DIFF
--- a/grappelli/templates/admin/widgets/related_widget_wrapper.html
+++ b/grappelli/templates/admin/widgets/related_widget_wrapper.html
@@ -1,0 +1,42 @@
+{% load i18n admin_static %}
+<div class="grp-related-widget-wrapper related-widget-wrapper">
+    {{ rendered_widget }}
+    {% block links %}
+        {% if can_change_related or can_add_related or can_delete_related %}
+            <ul class="grp-tools grp-related-widget-tools">
+                {% comment %}
+                {% if can_change_related %}
+                    <li>
+                        <a class="grp-related-widget-wrapper-link grp-change-related related-widget-wrapper-link change-related" id="change_id_{{ name }}"
+                            data-href-template="{{ change_related_template_url }}?{{ url_params }}"
+                            title="{% blocktrans %}Change selected {{ model }}{% endblocktrans %}">
+                            <img src="{% static 'admin/img/icon-changelink.svg' %}" width="10" height="10"
+                                alt="{% trans 'Change' %}"/>
+                        </a>
+                    </li>
+                {% endif %}
+                {% endcomment %}
+                {% if can_add_related %}
+                    <li>
+                        <a class="grp-related-widget-wrapper-link grp-add-related grp-add-another related-widget-wrapper-link add-related add-another" id="add_id_{{ name }}"
+                            href="{{ add_related_url }}?{{ url_params }}"
+                            title="{% blocktrans %}Add another {{ model }}{% endblocktrans %}">
+                        </a>
+                    </li>
+                {% endif %}
+                {% comment %}
+                {% if can_delete_related %}
+                    <li>
+                        <a class="grp-related-widget-wrapper-link grp-delete-related related-widget-wrapper-link delete-related" id="delete_id_{{ name }}"
+                            data-href-template="{{ delete_related_template_url }}?{{ url_params }}"
+                            title="{% blocktrans %}Delete selected {{ model }}{% endblocktrans %}">
+                            <img src="{% static 'admin/img/icon-deletelink.svg' %}" width="10" height="10"
+                                alt="{% trans 'Delete' %}"/>
+                        </a>
+                    </li>
+                {% endif %}
+                {% endcomment %}
+            </ul>
+        {% endif %}
+    {% endblock %}
+</div>

--- a/grappelli/templatetags/grp_tags.py
+++ b/grappelli/templatetags/grp_tags.py
@@ -17,7 +17,6 @@ from django.utils.formats import get_format
 from django.utils.safestring import mark_safe
 from django.utils.translation import get_language
 from django.template.loader import get_template
-from django.template.context import Context
 from django.utils.translation import ugettext as _
 
 # grappelli imports
@@ -214,11 +213,11 @@ def admin_list_filter(cl, spec):
         tpl = get_template(cl.model_admin.change_list_filter_template)
     except:
         tpl = get_template(spec.template)
-    return tpl.render(Context({
+    return tpl.render({
         'title': spec.title,
         'choices': list(spec.choices(cl)),
         'spec': spec,
-    }))
+    })
 
 
 @register.simple_tag(takes_context=True)


### PR DESCRIPTION
See https://github.com/django/django/commit/a3e783fe11dd25bbf84bfb6201186566ed473506
Passing a passing a Context is deprecated since Django 1.8. It's now raising a TypeError exception "context must be a dict rather than Context" with Django 1.11