### PR TITLE
Fix formsetsort templtag

### DIFF
--- a/grappelli/templatetags/grp_tags.py
+++ b/grappelli/templatetags/grp_tags.py
@@ -123,23 +123,28 @@ def classpath(obj):
 
 # FORMSETSORT FOR SORTABLE INLINES
 
+
 @register.filter
 def formsetsort(formset, arg):
     """
     Takes a list of formset dicts, returns that list sorted by the sortable field.
     """
+
     if arg:
         sorted_list = []
+        unsorted_list = []
         for item in formset:
-            position = item.form[arg].data
-            if position and position != "-1":
+            position = item.form[arg].value()
+
+            if isinstance(position, int) and item.original: # normal view
+                sorted_list.append((position, item))
+            elif position and item.form.cleaned_data:       # error validation view
                 sorted_list.append((int(position), item))
+            else:
+                unsorted_list.append(item)
+
         sorted_list.sort(key=lambda i: i[0])
-        sorted_list = [item[1] for item in sorted_list]
-        for item in formset:
-            position = item.form[arg].data
-            if not position or position == "-1":
-                sorted_list.append(item)
+        sorted_list = [item[1] for item in sorted_list] + unsorted_list
     else:
         sorted_list = formset
     return sorted_list

--- a/grappelli/templatetags/grp_tags.py
+++ b/grappelli/templatetags/grp_tags.py
@@ -134,7 +134,7 @@ def formsetsort(formset, arg):
             position = item.form[arg].data
             if position and position != "-1":
                 sorted_list.append((int(position), item))
-        sorted_list.sort()
+        sorted_list.sort(key=lambda i: i[0])
         sorted_list = [item[1] for item in sorted_list]
         for item in formset:
             position = item.form[arg].data

--- a/grappelli/templatetags/grp_tags.py
+++ b/grappelli/templatetags/grp_tags.py
@@ -129,7 +129,6 @@ def formsetsort(formset, arg):
     """
     Takes a list of formset dicts, returns that list sorted by the sortable field.
     """
-
     if arg:
         sorted_list = []
         unsorted_list = []
@@ -138,7 +137,7 @@ def formsetsort(formset, arg):
 
             if isinstance(position, int) and item.original: # normal view
                 sorted_list.append((position, item))
-            elif position and item.form.cleaned_data:       # error validation view
+            elif position and hasattr(item.form, 'cleaned_data'): # error validation view
                 sorted_list.append((int(position), item))
             else:
                 unsorted_list.append(item)


### PR DESCRIPTION
At first I experienced TypeError exception while using sortable inline with following combination:
- Python 3
- GrappelliSortableHiddenMixin
- having `default` param set to 0 on position field
- making form validation error (the exception was thrown while rendering validation error view)

Then it turned out that GrappelliSortableHiddenMixin breaks inline sorting on normal (non-error) view,
which might be confusing if you dont set `ordering` attribute - thats why I decided to refactor this.