### PR TITLE
Link list target

### DIFF
--- a/docs/dashboard_api.rst
+++ b/docs/dashboard_api.rst
@@ -142,7 +142,13 @@ following keys:
     A string describing the link, it will be the ``title`` attribute of
     the html ``a`` tag.
 
-Children can also be iterables (lists or tuples) of length 2, 3 or 4.
+``target``
+    A string or boolean value describing what is the link target. To open
+    link in a new window/tab you can pass ``True`` or ``'_blank'`` value to
+    this parameter. When you pass an string value, it is directly used in
+    the ``target`` attribute of the generated ``a`` tag in the template.
+
+Children can also be iterables (lists or tuples) of length 2, 3, 4, or 5.
 
 Here's an example of building a link list module:
 
@@ -163,6 +169,7 @@ Here's an example of building a link list module:
                         'url': 'http://www.python.org',
                         'external': True,
                         'description': 'Python programming language rocks!',
+                        'target': '_blank',
                     },
                     ['Django website', 'http://www.djangoproject.com', True],
                     ['Some internal link', '/some/internal/link/'],

--- a/grappelli/dashboard/dashboards.py
+++ b/grappelli/dashboard/dashboards.py
@@ -171,11 +171,13 @@ class DefaultIndexDashboard(Dashboard):
                     'title': _('Django documentation'),
                     'url': 'http://docs.djangoproject.com/',
                     'external': True,
+                    'target': '_blank',
                 },
                 {
                     'title': _('Django "django-users" mailing list'),
                     'url': 'http://groups.google.com/group/django-users',
                     'external': True,
+                    'target': True,  # ~= open in new window: True
                 },
                 {
                     'title': _('Django irc channel'),

--- a/grappelli/dashboard/modules.py
+++ b/grappelli/dashboard/modules.py
@@ -197,6 +197,12 @@ class LinkList(DashboardModule):
                     link_dict['external'] = link[2]
                 if len(link) >= 4:
                     link_dict['description'] = link[3]
+                if len(link) >= 5:
+                    target = link[4]
+                    if isinstance(target, bool):
+                        target = '_blank' if target else None
+                    if target:
+                        link_dict['target'] = str(target)
                 new_children.append(link_dict)
             else:
                 new_children.append(link)

--- a/grappelli/dashboard/templates/grappelli/dashboard/modules/link_list.html
+++ b/grappelli/dashboard/templates/grappelli/dashboard/modules/link_list.html
@@ -5,7 +5,7 @@
         {% spaceless %}
             {% for child in module.children %}
                 <li class="grp-row">
-                    <a class="{% if child.external %}grp-link-external{% else %}grp-link-internal{% endif %}" href="{{ child.url }}" {% if child.description %} title="{{ child.description }}"{% endif %}>{{ child.title }}</a>
+                    <a class="{% if child.external %}grp-link-external{% else %}grp-link-internal{% endif %}" href="{{ child.url }}" {% if child.description %} title="{{ child.description }}"{% endif %}{%if child.target %} target="{{ child.target }}"{% endif %}>{{ child.title }}</a>
                 </li>
             {% endfor %}
         {% endspaceless %}


### PR DESCRIPTION
Hello.

I added a fifth parameter to the link list items allowing the developer to specify whether the link should open in a new window/tab. 
All 9 tests were passed.
I tested it using Python 3.5.3 and Django 1.11.4 on Grappelli 2.10
Did not forget to update the example and docs, updated them in a separate commit.

(I hope that I haven't messed up the branching or other contribution criteria BTW :blush: )