### PR TITLE
Use django.urls instead of django.core.urlresolvers to import reverse

### DIFF
--- a/docs/dashboard_api.rst
+++ b/docs/dashboard_api.rst
@@ -27,7 +27,7 @@ Here's an example of a custom dashboard:
 
 .. code-block:: python
 
-    from django.core.urlresolvers import reverse
+    from django.urls import reverse
     from django.utils.translation import ugettext_lazy as _
     from grappelli.dashboard import modules, Dashboard
 

--- a/grappelli/dashboard/dashboards.py
+++ b/grappelli/dashboard/dashboards.py
@@ -7,7 +7,7 @@ Module where grappelli dashboard classes are defined.
 # DJANGO IMPORTS
 from django.utils import six
 from django.utils.translation import ugettext_lazy as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django import forms
 
 # GRAPPELLI IMPORTS
@@ -55,7 +55,7 @@ class Dashboard(six.with_metaclass(forms.MediaDefiningClass)):
 
     Here's an example of a custom dashboard::
 
-        from django.core.urlresolvers import reverse
+        from django.urls import reverse
         from django.utils.translation import ugettext_lazy as _
         from admin_tools.dashboard import modules, Dashboard
 

--- a/grappelli/dashboard/templates/grappelli/dashboard/dashboard.txt
+++ b/grappelli/dashboard/templates/grappelli/dashboard/dashboard.txt
@@ -7,7 +7,7 @@ To activate your index dashboard add the following to your settings.py::
 """
 
 from django.utils.translation import ugettext_lazy as _
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from grappelli.dashboard import modules, Dashboard
 from grappelli.dashboard.utils import get_admin_site_name

--- a/grappelli/dashboard/templatetags/grp_dashboard_tags.py
+++ b/grappelli/dashboard/templatetags/grp_dashboard_tags.py
@@ -10,7 +10,7 @@ To load the dashboard tags: ``{% load grp_dashboard_tags %}``.
 
 # DJANGO IMPORTS
 from django import template
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 # GRAPPELLI IMPORTS
 from grappelli.dashboard.utils import get_admin_site_name, get_index_dashboard

--- a/grappelli/dashboard/utils.py
+++ b/grappelli/dashboard/utils.py
@@ -12,7 +12,7 @@ from importlib import import_module
 # DJANGO IMPORTS
 from django.conf import settings
 from django.contrib import admin
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 
 def _get_dashboard_cls(dashboard_cls, context):

--- a/grappelli/tests/test_related.py
+++ b/grappelli/tests/test_related.py
@@ -7,7 +7,7 @@ import datetime
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import six, translation, timezone
 
 try:

--- a/grappelli/tests/test_switch.py
+++ b/grappelli/tests/test_switch.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from django.contrib.auth.models import User, Permission
 from django.contrib.contenttypes.models import ContentType
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.html import escape
 from django.utils.translation import ugettext_lazy as _
 


### PR DESCRIPTION
Replaces references to removed django.core.urlresolvers with django.urls for imports of reverse().

May help with #825 for Django 2.0 support.