### PR TITLE
Fix Django version (1.11 => 2.0) for Grappelli 2.11 in quickstart.rst

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -38,6 +38,8 @@ Add URL-patterns. The grappelli URLs are needed for related–lookups and autoco
 
 .. code-block:: python
 
+    from django.conf.urls import include
+    ...
     urlpatterns = [
         path('grappelli/', include('grappelli.urls')), # grappelli URLS
         path('admin/', admin.site.urls), # admin site

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -38,7 +38,7 @@ Add URL-patterns. The grappelli URLs are needed for related–lookups and autoco
 
 .. code-block:: python
 
-    from django.conf.urls import include
+    from django.urls import include
     ...
     urlpatterns = [
         path('grappelli/', include('grappelli.urls')), # grappelli URLS

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,13 +1,17 @@
 .. |grappelli| replace:: Grappelli
 .. |filebrowser| replace:: FileBrowser
 .. |grappelliversion| replace:: 2.11.1
+.. _applicableversionofdjango: http://www.djangoproject.com
+.. |applicableversionofdjango| replace:: Django 2.0
+.. _adminsite: http://docs.djangoproject.com/en/2.0/ref/contrib/admin 
+.. |adminsite| replace:: Admin Site
 
 .. _quickstart:
 
 Quick start guide
 =================
 
-For using |grappelli| |grappelliversion|, `Django 1.11 <http://www.djangoproject.com>`_ needs to be installed and an `Admin Site <http://docs.djangoproject.com/en/1.11/ref/contrib/admin/>`_ has to be activated.
+For using |grappelli| |grappelliversion|, |applicableversionofdjango|_ needs to be installed and an |adminsite|_ has to be activated.
 
 Installation
 ------------


### PR DESCRIPTION
From http://django-grappelli.readthedocs.io/en/latest/index.html:

> Grappelli 2.11.1 (January 27th, 2018): Compatible with Django 2.0

* So it appears that `Django 1.11` needs to be corrected to `Django 2.0`

---

Have taken this a step further in the hope that it will make future updates easier.  While there is no apparent way to remove the duplication entirely, the new structure has its advantages:

1. The changeable values are gathered together at the top of the file
1. The duplication of the Django version number has been horizontally aligned across consecutive lines, making it easier to make the amendments