### PR TITLE
Incorporate `Reset to default` functionality from `constance`

### DIFF
--- a/grappelli/templates/admin/constance/change_list.html
+++ b/grappelli/templates/admin/constance/change_list.html
@@ -27,6 +27,25 @@
                     text = text.replace(/<br>.*: /, "");
                     $(this).html(text);
                 });
+                $('#grp-changelist.grp-editable').on('click', '.reset-link', function(e) {
+                    e.preventDefault();
+
+                    var field = $('#' + this.dataset.fieldId);
+                    var fieldType = this.dataset.fieldType;
+
+                    if (fieldType === 'checkbox') {
+                        field.prop('checked', this.dataset.default === 'true');
+                    } else if (fieldType === 'date') {
+                        var defaultDate = new Date(this.dataset.default * 1000);
+                        $('#' + this.dataset.fieldId).val(defaultDate.strftime(get_format('DATE_INPUT_FORMATS')[0]));
+                    } else if (fieldType === 'datetime') {
+                        var defaultDate = new Date(this.dataset.default * 1000);
+                        $('#' + this.dataset.fieldId + '_0').val(defaultDate.strftime(get_format('DATE_INPUT_FORMATS')[0]));
+                        $('#' + this.dataset.fieldId + '_1').val(defaultDate.strftime(get_format('TIME_INPUT_FORMATS')[0]));
+                    } else {
+                        field.val(this.dataset.default);
+                    }
+                });
             });
         })(grp.jQuery);
     </script>

--- a/grappelli/templates/admin/constance/change_list.html
+++ b/grappelli/templates/admin/constance/change_list.html
@@ -9,6 +9,16 @@
     {{ media.css }}
 {% endblock %}
 
+<!-- EXTRASTYLES -->
+{% block extrastyle %}
+  {{ block.super }}
+  <style type="text/css">
+    h2 {
+        line-height: 36px;
+    }
+  </style>
+{% endblock %}
+
 <!-- JAVASCRIPTS -->
 {% block javascripts %}
     {{ block.super }}

--- a/grappelli/templates/admin/constance/includes/results_list.html
+++ b/grappelli/templates/admin/constance/includes/results_list.html
@@ -49,6 +49,23 @@
                         {% else %}
                             <img src="{% static 'admin/img/icon-no.'|add:icon_type %}" alt="{{ item.modified }}" />
                         {% endif %}
+                        <br />
+                        <a href="#" class="reset-link"
+                            data-field-id="{{ item.form_field.auto_id }}"
+                            data-field-type="{% spaceless %}
+                            {% if item.is_checkbox %}checkbox
+                            {% elif item.is_date %}date
+                            {% elif item.is_datetime %}datetime
+                            {% endif %}
+                            {% endspaceless %}"
+                            data-default="{% spaceless %}
+                            {% if item.is_checkbox %}{% if item.raw_default %} true {% else %} false {% endif %}
+                            {% elif item.is_date %}{{ item.raw_default|date:"U" }}
+                            {% elif item.is_datetime %}{{ item.raw_default|date:"U" }}
+                            {% else %}{{ item.default }}
+                            {% endif %}
+                            {% endspaceless %}">{% trans "Reset to default" %}
+                        </a>
                     </td>
                 </tr>
             {% endfor %}

--- a/grappelli/templates/admin/constance/includes/results_list.html
+++ b/grappelli/templates/admin/constance/includes/results_list.html
@@ -43,7 +43,7 @@
                             </ul>
                         {% endif %}
                     </td>
-                    <td>
+                    <td style="text-align: center;">
                         {% if item.modified %}
                             <img src="{% static 'admin/img/icon-yes.'|add:icon_type %}" alt="{{ item.modified }}" />
                         {% else %}


### PR DESCRIPTION
### Summary

* With necessary and additional modifications
  - JS placed under `change_list.html`
  - `Reset to default` anchor placed beneath icon instead of value
* Source files:
  - `.../constance/templates/admin/constance/includes/results_list.html`
  - `.../constance/static/admin/js/constance.js`
* Second commit (CSS)
  - Vertical spacing is needed, particularly between the groups of options

### Screenshot: Before this PR

![screenshot53](https://user-images.githubusercontent.com/10231489/39719228-7e66cd18-5230-11e8-848f-8016f2c483bb.png)

### Screenshot: After this PR

![screenshot54](https://user-images.githubusercontent.com/10231489/39719252-93277072-5230-11e8-874b-7dd647720fb8.png)