### PR TITLE
Ensure LICENSE is included in the built wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal=1
+
+[metadata]
+license_file=LICENSE


### PR DESCRIPTION
Without this directive the LICENSE file is absent from a built wheel.
With it it will end up in the dist-info wheel dir

Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>