### PR TITLE
Fix reversion template localization bug using upstream fix

### DIFF
--- a/grappelli/templates/reversion/recover_list.html
+++ b/grappelli/templates/reversion/recover_list.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_urls %}
+{% load i18n l10n admin_urls %}
 
 {% block breadcrumbs %}
     <ul>
@@ -26,7 +26,7 @@
                 <tbody>
                     {% for deletion in deleted %}
                         <tr>
-                            <th scope="grp-row"><a href="{{ deletion.pk }}/">{{ deletion.revision.date_created }}</a></th>
+                            <th scope="grp-row"><a href="{{ deletion.pk|unlocalize }}/">{{ deletion.revision.date_created }}</a></th>
                             <td>{{ deletion.object_repr }}</td>
                         </tr>
                     {% endfor %}


### PR DESCRIPTION
Problem is as mentioned in the [upstream PR](https://github.com/etianen/django-reversion/pull/601):

> When deletion.pk is larger than 1k in some localizations settings Django adds space between thousnads (for example: "1 000") and cause bug in url (creates inaccesible url)