### PR TITLE
Allows to view list of object on "view" permission

### DIFF
--- a/grappelli/templates/admin/app_index.html
+++ b/grappelli/templates/admin/app_index.html
@@ -24,7 +24,7 @@
                     <h2>{% trans app.name %}</h2>
                     {% for model in app.models %}
                         <div class="grp-row">
-                            {% if model.perms.change %}<a href="{{ model.admin_url }}"><strong>{{ model.name }}</strong></a>{% else %}<span><strong>{{ model.name }}</strong></span>{% endif %}
+                            {% if model.perms.change or model.perms.view %}<a href="{{ model.admin_url }}"><strong>{{ model.name }}</strong></a>{% else %}<span><strong>{{ model.name }}</strong></span>{% endif %}
                             {% if model.perms.add %}
                                 <ul class="grp-actions">
                                     {% if model.perms.add %}<li class="grp-icon grp-add-link"><a href="{{ model.add_url }}" title="{% trans 'Add' %}">&nbsp;</a></li>{% endif %}


### PR DESCRIPTION
Similiar to https://github.com/sehmaschine/django-grappelli/pull/867 but in different part of application.

Django 2.1 added ```view_``` permission.