### PR TITLE
base.html: fix admin-title when using translations

### DIFF
--- a/grappelli/templates/admin/base.html
+++ b/grappelli/templates/admin/base.html
@@ -78,7 +78,8 @@
                             {% block branding %}{% endblock %}
                             {% block admin_title %}
                                 <h1 id="grp-admin-title">
-                                    {% if site_header and site_header != "Django administration" %}
+                                    {% trans "Django administration" as vanilla_site_header %}
+                                    {% if site_header and site_header != vanilla_site_header %}
                                         {{ site_header|safe }}
                                     {% elif grappelli_admin_title %}
                                         {{ grappelli_admin_title }}


### PR DESCRIPTION
When a non-english translation is active the translated version of "Django administration" was always shown as the admin-title.
Now we compare against the translated string.
introduced in https://github.com/sehmaschine/django-grappelli/commit/1361f4cca9990fd897398d342ed324c168285acb