### PR TITLE
admin/pagination.html: honor cl.show_full_result_count

### DIFF
--- a/grappelli/templates/admin/pagination.html
+++ b/grappelli/templates/admin/pagination.html
@@ -3,18 +3,35 @@
 <nav class="grp-pagination">
     <header style="display:none"><h1>Pagination</h1></header>
     <ul>
-        {% if cl.result_count != cl.full_result_count %}
-            <li class="grp-results"><span>
-                {% blocktrans count cl.result_count as counter %}{{ counter }} result{% plural %}{{ counter }} results{% endblocktrans %}
-            </span></li>
-        {% endif %}
-        <li class="grp-results">
-            {% if cl.result_count != cl.full_result_count or cl.show_all %}
-                <a href="?{% if cl.is_popup %}_popup=1{% endif %}" class="total">{% blocktrans with cl.full_result_count as full_result_count %}{{ full_result_count }} total{% endblocktrans %}</a>
-            {% else %}
-                <span>{% blocktrans with cl.full_result_count as full_result_count %}{{ full_result_count }} total{% endblocktrans %}</span>
+        {% if cl.show_full_result_count %}
+            {% if cl.result_count != cl.full_result_count %}
+                <li class="grp-results"><span>
+                    {% blocktrans count cl.result_count as counter %}{{ counter }} result{% plural %}{{ counter }} results{% endblocktrans %}
+                </span></li>
             {% endif %}
-        </li>
+                <li class="grp-results">
+                    {% if cl.result_count != cl.full_result_count or cl.show_all %}
+                        <a href="?{% if cl.is_popup %}_popup=1{% endif %}" class="total">{% blocktrans with cl.full_result_count as full_result_count %}{{ full_result_count }} total{% endblocktrans %}</a>
+                    {% else %}
+                        <span>{% blocktrans with cl.full_result_count as full_result_count %}{{ full_result_count }} total{% endblocktrans %}</span>
+                    {% endif %}
+                </li>
+        {% else %}
+            <li class="grp-results">
+                <span>
+                    {% blocktrans count cl.result_count as counter %}
+                        {{ counter }} result
+                    {% plural %}
+                        {{ counter }} results
+                    {% endblocktrans %}
+                </span>
+            </li>
+            <li class="grp-results">
+                <a href="?{% if cl.is_popup %}_popup=1{% endif %}" class="total">
+                    {% trans "Show all" %}
+                </a>
+            </li>
+        {% endif %}
         {% if pagination_required %}
             {% for i in page_range %}
                 {% ifequal i "." %}


### PR DESCRIPTION
if `ModelAdmin.show_full_result_count` is set to `False` (to save an expensive COUNT(*) for large tables) the pagination would show "None total".

with this fix the "Show all" link is always shown when `show_full_result_count` is `False`

unfortunately there is no way to exactly keep grappelli's behavior of skipping the "show all" link when the results are not filtered (cl.result_count != cl.full_result_count)
that's why the change is a bit verbose, keeping the original code and adding a case where `show_full_result_count` is `False`