### PR TITLE
Fix Django deprecation warning [master]

### DIFF
--- a/grappelli/templates/admin/auth/user/change_password.html
+++ b/grappelli/templates/admin/auth/user/change_password.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_static admin_urls %}
+{% load i18n static admin_urls %}
 
 {% block breadcrumbs %}
     {% if not is_popup %}

--- a/grappelli/templates/admin/base.html
+++ b/grappelli/templates/admin/base.html
@@ -1,4 +1,4 @@
-{% load admin_static %}{% load i18n grp_tags %}
+{% load static %}{% load i18n grp_tags %}
 <!DOCTYPE html>
 {% get_current_language as LANGUAGE_CODE %}{% get_current_language_bidi as LANGUAGE_BIDI %}
 <html lang="{{ LANGUAGE_CODE|default:"en-us" }}" {% if LANGUAGE_BIDI %}dir="rtl"{% endif %}>

--- a/grappelli/templates/admin/change_form.html
+++ b/grappelli/templates/admin/change_form.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 
 <!-- LOADING -->
-{% load admin_static i18n admin_modify admin_urls grp_tags %}
+{% load static i18n admin_modify admin_urls grp_tags %}
 
 <!-- STYLESHEETS -->
 {% block stylesheets %}

--- a/grappelli/templates/admin/change_list.html
+++ b/grappelli/templates/admin/change_list.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 
 <!-- LOADING -->
-{% load i18n grp_tags admin_urls admin_static admin_list %}
+{% load i18n grp_tags admin_urls static admin_list %}
 
 <!-- STYLESHEETS -->
 {% block stylesheets %}

--- a/grappelli/templates/admin/change_list_results.html
+++ b/grappelli/templates/admin/change_list_results.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static %}
+{% load i18n static %}
 {% if result_hidden_fields %}
     <div class="hiddenfields"> {# DIV for HTML validation #}
         {% for item in result_hidden_fields %}{{ item }}{% endfor %}

--- a/grappelli/templates/admin/constance/includes/results_list.html
+++ b/grappelli/templates/admin/constance/includes/results_list.html
@@ -1,4 +1,4 @@
-{% load admin_static admin_list i18n %}
+{% load static admin_list i18n %}
 <div class="grp-module grp-changelist-results">
     <table id="result_list" cellspacing="0" class="grp-table grp-sortable">
         <thead>

--- a/grappelli/templates/admin/edit_inline/stacked.html
+++ b/grappelli/templates/admin/edit_inline/stacked.html
@@ -1,4 +1,4 @@
-{% load admin_urls admin_static i18n grp_tags %}
+{% load admin_urls static i18n grp_tags %}
 
 <!-- group -->
 <div class="inline-group grp-group grp-stacked {% if inline_admin_formset.opts.classes %} {{ inline_admin_formset.opts.classes|join:" " }}{% endif %}"

--- a/grappelli/templates/admin/related_widget_wrapper.html
+++ b/grappelli/templates/admin/related_widget_wrapper.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static %}
+{% load i18n static %}
 <div class="grp-related-widget-wrapper related-widget-wrapper">
     {{ widget }}
     {% block links %}

--- a/grappelli/templates/admin/widgets/related_widget_wrapper.html
+++ b/grappelli/templates/admin/widgets/related_widget_wrapper.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static %}
+{% load i18n static %}
 <div class="grp-related-widget-wrapper related-widget-wrapper">
     <div class="grp-related-widget">{{ rendered_widget }}</div>
     {% block links %}

--- a/grappelli/templates/grp_doc/basic_page_structure.html
+++ b/grappelli/templates/grp_doc/basic_page_structure.html
@@ -64,7 +64,7 @@
             </div>
             <div class="g-d-24">
                 <div class="grp-doc-code"><pre><code>{% filter force_escape %}
-{% templatetag openblock %} load i18n admin_static admin_modify grp_tags {% templatetag closeblock %}
+{% templatetag openblock %} load i18n static admin_modify grp_tags {% templatetag closeblock %}
 {% endfilter %}</code></pre></div>
             </div>
         </section>

--- a/grappelli/templates/grp_doc/change_form.html
+++ b/grappelli/templates/grp_doc/change_form.html
@@ -50,7 +50,7 @@
             <div class="g-d-24">
                 <div class="grp-doc-code"><pre><code>{% filter force_escape %}
 {% templatetag openblock %} extends "admin/base_site.html" {% templatetag closeblock %}
-{% templatetag openblock %} load i18n admin_static admin_modify grp_tags {% templatetag closeblock %}
+{% templatetag openblock %} load i18n static admin_modify grp_tags {% templatetag closeblock %}
 {% templatetag openblock %} block bodyclass {% templatetag closeblock %}grp-change-form{% templatetag openblock %} endblock {% templatetag closeblock %}
 {% endfilter %}</code></pre></div>
             </div>
@@ -237,7 +237,7 @@
             <div class="g-d-24">
                 <div class="grp-doc-code"><pre><code>{% filter force_escape %}
 {% templatetag openblock %} extends "admin/base_site.html" {% templatetag closeblock %}
-{% templatetag openblock %} load i18n admin_static admin_modify grp_tags {% templatetag closeblock %}
+{% templatetag openblock %} load i18n static admin_modify grp_tags {% templatetag closeblock %}
 
 {% templatetag openblock %} block extrastyle {% templatetag closeblock %}
     <link href="Path to your custom stylesheet" rel="stylesheet" type="text/css" />

--- a/grappelli/templates/grp_doc/change_list.html
+++ b/grappelli/templates/grp_doc/change_list.html
@@ -50,7 +50,7 @@
             <div class="g-d-24">
                 <div class="grp-doc-code"><pre><code>{% filter force_escape %}
 {% templatetag openblock %} extends "admin/base_site.html" {% templatetag closeblock %}
-{% templatetag openblock %} load i18n admin_static admin_modify grp_tags {% templatetag closeblock %}
+{% templatetag openblock %} load i18n static admin_modify grp_tags {% templatetag closeblock %}
 {% templatetag openblock %} block bodyclass {% templatetag closeblock %}grp-change-list{% templatetag openblock %} endblock {% templatetag closeblock %}
 {% endfilter %}</code></pre></div>
             </div>
@@ -314,7 +314,7 @@
             <div class="g-d-24">
                 <div class="grp-doc-code"><pre><code>{% filter force_escape %}
 {% templatetag openblock %} extends "admin/base_site.html" {% templatetag closeblock %}
-{% templatetag openblock %} load i18n admin_static admin_modify grp_tags {% templatetag closeblock %}
+{% templatetag openblock %} load i18n static admin_modify grp_tags {% templatetag closeblock %}
 {% templatetag openblock %} block bodyclass {% templatetag closeblock %}grp-change-list{% templatetag openblock %} endblock {% templatetag closeblock %}
 
 {% templatetag openblock %} block stylesheets {% templatetag closeblock %}

--- a/grappelli/templates/grp_doc/index.html
+++ b/grappelli/templates/grp_doc/index.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n admin_static admin_modify grp_tags %}
+{% load i18n static admin_modify grp_tags %}
 {% block bodyclass %}grp-doc{% endblock %}
 {% block content-class %}{% endblock %}
 {% block title %}Grappelli Documentation{% endblock %}

--- a/grappelli/templates/related_widget_wrapper.html
+++ b/grappelli/templates/related_widget_wrapper.html
@@ -1,4 +1,4 @@
-{% load i18n admin_static %}
+{% load i18n static %}
 <div class="related-widget-wrapper">
     {{ widget }}
     {% block links %}


### PR DESCRIPTION
`load admin_static is deprecated in favor of load static`

Fixes #864