### PR TITLE
Trigger change event in dismissChangeRelatedObjectPopup

### DIFF
--- a/grappelli/static/admin/js/admin/RelatedObjectLookups.js
+++ b/grappelli/static/admin/js/admin/RelatedObjectLookups.js
@@ -114,7 +114,7 @@
                 this.textContent = newRepr;
                 this.value = newId;
             }
-        });
+        }).trigger('change');
         // GRAPPELLI CUSTOM: element focus
         elem.focus();
         win.close();


### PR DESCRIPTION
In order for other add on libraries to function properly, like django-select2-forms the change even needs to be triggered even when you just change the title of the option within the dropdown. This allows these libraries to update their proxy representation in response to the changed name.