### PR TITLE
Fix CSS to show full multi-select form element

### DIFF
--- a/grappelli/compass/sass/partials/forms/_forms.scss
+++ b/grappelli/compass/sass/partials/forms/_forms.scss
@@ -58,7 +58,7 @@ input[type="number"],
 input[type="submit"],
 input[type="reset"],
 textarea,
-select {
+select:not([multiple]) {
     @include grp-form-field;
     .grp-errors & {
         border-color: $grp-font-color-error;


### PR DESCRIPTION
Previously, the include added a height of 25px to the select[multiple] inputs, which made them un-usable.  This avoids adding the height restriction to the multiple-input selects.

Previous to fix:

<img width="1265" alt="Screen Shot 2019-07-14 at 2 29 53 PM" src="https://user-images.githubusercontent.com/1065913/61188011-2713ab00-a647-11e9-8a9c-a16fa5e5dde5.png">

After fix:

<img width="682" alt="Screen Shot 2019-07-14 at 2 47 32 PM" src="https://user-images.githubusercontent.com/1065913/61188013-2aa73200-a647-11e9-9279-e40cb2e2ee9e.png">
