### PR TITLE
Link to latest docs

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -7,7 +7,7 @@
 Quick start guide
 =================
 
-For using |grappelli| |grappelliversion|, `Django 2.2 <http://www.djangoproject.com>`_ needs to be installed and an `Admin Site <http://docs.djangoproject.com/en/2.0/ref/contrib/admin/>`_ has to be activated.
+For using |grappelli| |grappelliversion|, `Django 2.2 <http://www.djangoproject.com>`_ needs to be installed and an `Admin Site <http://docs.djangoproject.com/en/stable/ref/contrib/admin/>`_ has to be activated.
 
 Installation
 ------------


### PR DESCRIPTION
Fix a link in the docs to point to the latest Django docs.