### PR TITLE
Test with Django 3.1 & fix deprecation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,13 @@ language: python
 matrix:
   include:
     - python: 3.6
-      env: TOXENV=py36
+      env: TOXENV=py36-django30
     - python: 3.7
-      env: TOXENV=py37
+      env: TOXENV=py37-django30
     - python: 3.8
-      env: TOXENV=py38
+      env: TOXENV=py38-django30
+    - python: 3.8
+      env: TOXENV=py38-django31
 install:
   - pip install tox
   - pip install coverage

--- a/grappelli/tests/urls.py
+++ b/grappelli/tests/urls.py
@@ -1,13 +1,14 @@
 # coding: utf-8
 
 # DJANGO IMPORTS
-from django.conf.urls import include, url
+from django.urls import re_path
+from django.conf.urls import include
 
 # GRAPPELLI IMPORTS
 from grappelli.tests import admin
 
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url(r'^grappelli/', include('grappelli.urls'))
+    re_path(r'^admin/', admin.site.urls),
+    re_path(r'^grappelli/', include('grappelli.urls'))
 ]

--- a/grappelli/urls.py
+++ b/grappelli/urls.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from django.conf.urls import url
+from django.urls import re_path
 
 from .views.related import AutocompleteLookup, M2MLookup, RelatedLookup
 from .views.switch import switch_user
@@ -8,11 +8,11 @@ from .views.switch import switch_user
 urlpatterns = [
 
     # FOREIGNKEY & GENERIC LOOKUP
-    url(r'^lookup/related/$', RelatedLookup.as_view(), name="grp_related_lookup"),
-    url(r'^lookup/m2m/$', M2MLookup.as_view(), name="grp_m2m_lookup"),
-    url(r'^lookup/autocomplete/$', AutocompleteLookup.as_view(), name="grp_autocomplete_lookup"),
+    re_path(r'^lookup/related/$', RelatedLookup.as_view(), name="grp_related_lookup"),
+    re_path(r'^lookup/m2m/$', M2MLookup.as_view(), name="grp_m2m_lookup"),
+    re_path(r'^lookup/autocomplete/$', AutocompleteLookup.as_view(), name="grp_autocomplete_lookup"),
 
     # SWITCH USER
-    url(r'^switch/user/(?P<object_id>\d+)/$', switch_user, name="grp_switch_user"),
+    re_path(r'^switch/user/(?P<object_id>\d+)/$', switch_user, name="grp_switch_user"),
 
 ]

--- a/grappelli/urls_docs.py
+++ b/grappelli/urls_docs.py
@@ -1,44 +1,44 @@
 # coding: utf-8
 
 # DJANGO IMPORTS
-from django.conf.urls import url
+from django.urls import re_path
 from django.views.generic import TemplateView
 
 
 urlpatterns = [
 
     # GRAPPELLI DOM DOCUMENTATION
-    url(r'^change-form/', TemplateView.as_view(template_name='grp_doc/change_form.html'), name="grp_doc_change_form"),
-    url(r'^change-list/', TemplateView.as_view(template_name='grp_doc/change_list.html'), name="grp_doc_change_list"),
-    url(r'^admin-index/', TemplateView.as_view(template_name='grp_doc/admin_index.html'), name="grp_doc_admin_index"),
+    re_path(r'^change-form/', TemplateView.as_view(template_name='grp_doc/change_form.html'), name="grp_doc_change_form"),
+    re_path(r'^change-list/', TemplateView.as_view(template_name='grp_doc/change_list.html'), name="grp_doc_change_list"),
+    re_path(r'^admin-index/', TemplateView.as_view(template_name='grp_doc/admin_index.html'), name="grp_doc_admin_index"),
 
-    url(r'^tables/', TemplateView.as_view(template_name='grp_doc/tables.html'), name="grp_doc_tables"),
+    re_path(r'^tables/', TemplateView.as_view(template_name='grp_doc/tables.html'), name="grp_doc_tables"),
 
-    url(r'^pagination/', TemplateView.as_view(template_name='grp_doc/pagination.html'), name="grp_doc_pagination"),
-    url(r'^search-form/', TemplateView.as_view(template_name='grp_doc/search_form.html'), name="grp_doc_search_form"),
-    url(r'^filter/', TemplateView.as_view(template_name='grp_doc/filter.html'), name="grp_doc_filter"),
-    url(r'^date-hierarchy/', TemplateView.as_view(template_name='grp_doc/date_hierarchy.html'), name="grp_doc_date_hierarchy"),
+    re_path(r'^pagination/', TemplateView.as_view(template_name='grp_doc/pagination.html'), name="grp_doc_pagination"),
+    re_path(r'^search-form/', TemplateView.as_view(template_name='grp_doc/search_form.html'), name="grp_doc_search_form"),
+    re_path(r'^filter/', TemplateView.as_view(template_name='grp_doc/filter.html'), name="grp_doc_filter"),
+    re_path(r'^date-hierarchy/', TemplateView.as_view(template_name='grp_doc/date_hierarchy.html'), name="grp_doc_date_hierarchy"),
 
-    url(r'^fieldsets/', TemplateView.as_view(template_name='grp_doc/fieldsets.html'), name="grp_doc_fieldsets"),
-    url(r'^errors/', TemplateView.as_view(template_name='grp_doc/errors.html'), name="grp_doc_errors"),
-    url(r'^form-fields/', TemplateView.as_view(template_name='grp_doc/form_fields.html'), name="grp_doc_form_fields"),
-    url(r'^submit-rows/', TemplateView.as_view(template_name='grp_doc/submit_rows.html'), name="grp_doc_submit_rows"),
+    re_path(r'^fieldsets/', TemplateView.as_view(template_name='grp_doc/fieldsets.html'), name="grp_doc_fieldsets"),
+    re_path(r'^errors/', TemplateView.as_view(template_name='grp_doc/errors.html'), name="grp_doc_errors"),
+    re_path(r'^form-fields/', TemplateView.as_view(template_name='grp_doc/form_fields.html'), name="grp_doc_form_fields"),
+    re_path(r'^submit-rows/', TemplateView.as_view(template_name='grp_doc/submit_rows.html'), name="grp_doc_submit_rows"),
 
-    url(r'^modules/', TemplateView.as_view(template_name='grp_doc/modules.html'), name="grp_doc_modules"),
-    url(r'^groups/', TemplateView.as_view(template_name='grp_doc/groups.html'), name="grp_doc_groups"),
+    re_path(r'^modules/', TemplateView.as_view(template_name='grp_doc/modules.html'), name="grp_doc_modules"),
+    re_path(r'^groups/', TemplateView.as_view(template_name='grp_doc/groups.html'), name="grp_doc_groups"),
 
-    url(r'^navigation/', TemplateView.as_view(template_name='grp_doc/navigation.html'), name="grp_doc_navigation"),
-    url(r'^context-navigation/', TemplateView.as_view(template_name='grp_doc/context_navigation.html'), name="grp_doc_context_navigation"),
+    re_path(r'^navigation/', TemplateView.as_view(template_name='grp_doc/navigation.html'), name="grp_doc_navigation"),
+    re_path(r'^context-navigation/', TemplateView.as_view(template_name='grp_doc/context_navigation.html'), name="grp_doc_context_navigation"),
 
-    url(r'^basic-page-structure/', TemplateView.as_view(template_name='grp_doc/basic_page_structure.html'), name="grp_doc_basic_page_structure"),
+    re_path(r'^basic-page-structure/', TemplateView.as_view(template_name='grp_doc/basic_page_structure.html'), name="grp_doc_basic_page_structure"),
 
-    url(r'^tools/', TemplateView.as_view(template_name='grp_doc/tools.html'), name="grp_doc_tools"),
-    url(r'^object-tools/', TemplateView.as_view(template_name='grp_doc/object_tools.html'), name="grp_doc_object_tools"),
+    re_path(r'^tools/', TemplateView.as_view(template_name='grp_doc/tools.html'), name="grp_doc_tools"),
+    re_path(r'^object-tools/', TemplateView.as_view(template_name='grp_doc/object_tools.html'), name="grp_doc_object_tools"),
 
-    url(r'^mueller-grid-system-tests/', TemplateView.as_view(template_name='grp_doc/mueller_grid_system_tests.html'), name="grp_doc_mueller_grid_system_tests"),
-    url(r'^mueller-grid-system/', TemplateView.as_view(template_name='grp_doc/mueller_grid_system.html'), name="grp_doc_mueller_grid_system"),
-    url(r'^mueller-grid-system-layouts/', TemplateView.as_view(template_name='grp_doc/mueller_grid_system_layouts.html'), name="grp_doc_mueller_grid_system_layouts"),
+    re_path(r'^mueller-grid-system-tests/', TemplateView.as_view(template_name='grp_doc/mueller_grid_system_tests.html'), name="grp_doc_mueller_grid_system_tests"),
+    re_path(r'^mueller-grid-system/', TemplateView.as_view(template_name='grp_doc/mueller_grid_system.html'), name="grp_doc_mueller_grid_system"),
+    re_path(r'^mueller-grid-system-layouts/', TemplateView.as_view(template_name='grp_doc/mueller_grid_system_layouts.html'), name="grp_doc_mueller_grid_system_layouts"),
 
-    url(r'^', TemplateView.as_view(template_name='grp_doc/index.html'), name="grp_doc"),
+    re_path(r'^', TemplateView.as_view(template_name='grp_doc/index.html'), name="grp_doc"),
 
 ]

--- a/requirements/requirements-testing.txt
+++ b/requirements/requirements-testing.txt
@@ -1,4 +1,3 @@
-Django>=3.0,<3.1
 py==1.8.0
 pytest-django==3.6.0
 pytest==5.2.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py{36}
+envlist = py{36,37,38}-django30
+          py38-django31
 
 [testenv]
 setenv =
@@ -7,4 +8,6 @@ setenv =
 deps =
     -rrequirements/requirements-testing.txt
     coverage
+    django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
 commands = ./runtests.py {posargs}


### PR DESCRIPTION
I've added a test job for Django 3.1 which shows deprecation warnings here https://travis-ci.org/github/MrSenko/django-grappelli/jobs/719752483 and then fixed a few imports to make them go away (https://travis-ci.org/github/MrSenko/django-grappelli/jobs/719754680). 

Strangely enough the test jobs weren't running when this PR was opened and it looks like recent PRs also don't have test jobs executed against them hence the first commit.

@sehmaschine please review but I am curious to know what the reason for the missing test execution in CI is? Wouldn't you want to have tests running to see that they at least pass before merging a PR ?