### PR TITLE
Remove extra filtering in AutocompleteLookup

### DIFF
--- a/grappelli/views/related.py
+++ b/grappelli/views/related.py
@@ -225,7 +225,6 @@ class AutocompleteLookup(RelatedLookup):
 
     def get_queryset(self):
         qs = super(AutocompleteLookup, self).get_queryset()
-        qs = self.get_filtered_queryset(qs)
         qs = self.get_searched_queryset(qs)
 
         if connection.vendor == 'postgresql':


### PR DESCRIPTION
Seems like filtering is already done in `qs = super(AutocompleteLookup, self).get_queryset()` and there is no need to do it twice.
Fix greatly increases performance on complex joins.