### PR TITLE
#957 fix/dashboard-label for django 3.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ fabfile.py
 node_modules/*
 .tox/*
 .idea
+.venv/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
       env: TOXENV=py38-django30
     - python: 3.8
       env: TOXENV=py38-django31
+    - python: 3.9
+      env: TOXENV=py39-django32
 install:
   - pip install tox
   - pip install coverage

--- a/grappelli/dashboard/apps.py
+++ b/grappelli/dashboard/apps.py
@@ -6,5 +6,5 @@ from django.apps import AppConfig
 
 class DashboardConfig(AppConfig):
     name = "grappelli.dashboard"
-    label = "grappelli.dashboard"
+    label = "grappelli_dashboard"
     verbose_name = "Grappelli Dashboard"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist = py{36,37,38}-django30
           py38-django31
+          py39-django32
 
 [testenv]
 setenv =
@@ -10,4 +11,5 @@ deps =
     coverage
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
+    django32: Django>=3.2,<4.0
 commands = ./runtests.py {posargs}


### PR DESCRIPTION
This PR address and fixes the issue reported #957, by changing the dashboard app label from "grappelli.dashboard" to "grappelli_dashboard". 

This fixes the issue encountered with v3.2 of Django, which tests the app label using the [isidentifier() built-in method](https://www.w3schools.com/python/ref_string_isidentifier.asp). Please see the OP in issue 957 for explanation. 