### PR TITLE
docs: Fix a few typos

### DIFF
--- a/grappelli/static/grappelli/tinymce/jscripts/tiny_mce/plugins/autosave/editor_plugin_src.js
+++ b/grappelli/static/grappelli/tinymce/jscripts/tiny_mce/plugins/autosave/editor_plugin_src.js
@@ -27,7 +27,7 @@
  * 
  * 2. sessionStorage - A new feature of HTML 5, sessionStorage works similarly to localStorage,
  * except it is designed to expire after a certain amount of time.  Because the specification
- * around expiration date/time is very loosely-described, it is preferrable to use locaStorage and
+ * around expiration date/time is very loosely-described, it is preferable to use locaStorage and
  * manage the expiration ourselves.  sessionStorage has similar storage characteristics to
  * localStorage, although it seems to have better support by Firefox 3 at the moment.  (That will
  * certainly change as Firefox continues getting better at HTML 5 adoption.)

--- a/grappelli/static/grappelli/tinymce/jscripts/tiny_mce/plugins/media/editor_plugin_src.js
+++ b/grappelli/static/grappelli/tinymce/jscripts/tiny_mce/plugins/media/editor_plugin_src.js
@@ -147,7 +147,7 @@
 					});
 				}
 
-				// Add contect menu if it's loaded
+				// Add context menu if it's loaded
 				if (ed && ed.plugins.contextmenu) {
 					ed.plugins.contextmenu.onContextMenu.add(function(plugin, menu, element) {
 						if (element.nodeName === 'IMG' && element.className.indexOf('mceItemMedia') !== -1)

--- a/grappelli/static/grappelli/tinymce/jscripts/tiny_mce/plugins/media_orig/editor_plugin_src.js
+++ b/grappelli/static/grappelli/tinymce/jscripts/tiny_mce/plugins/media_orig/editor_plugin_src.js
@@ -147,7 +147,7 @@
 					});
 				}
 
-				// Add contect menu if it's loaded
+				// Add context menu if it's loaded
 				if (ed && ed.plugins.contextmenu) {
 					ed.plugins.contextmenu.onContextMenu.add(function(plugin, menu, element) {
 						if (element.nodeName === 'IMG' && element.className.indexOf('mceItemMedia') !== -1)


### PR DESCRIPTION
There are small typos in:
- grappelli/static/grappelli/tinymce/jscripts/tiny_mce/plugins/autosave/editor_plugin_src.js
- grappelli/static/grappelli/tinymce/jscripts/tiny_mce/plugins/media/editor_plugin_src.js
- grappelli/static/grappelli/tinymce/jscripts/tiny_mce/plugins/media_orig/editor_plugin_src.js

Fixes:
- Should read `context` rather than `contect`.
- Should read `preferable` rather than `preferrable`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md