### PR TITLE
chore: replace deprecated length_is template filter with length ==

### DIFF
--- a/grappelli/templates/admin/includes/fieldset.html
+++ b/grappelli/templates/admin/includes/fieldset.html
@@ -4,9 +4,9 @@
         {% if fieldset.name %}<h2 class="grp-collapse-handler">{{ fieldset.name }}</h2>{% endif %}
         {% if fieldset.description %}<div class="grp-row"><p class="grp-description">{{ fieldset.description|safe }}</p></div>{% endif %}
         {% for line in fieldset %}
-            <div class="form-row grp-row grp-cells-{{ line.fields|length }}{% if not line.fields|length_is:"1" %} grp-cells{% else %}{% if line.errors %} grp-errors{% endif %}{% endif %}{% if not line.has_visible_field %} grp-row-hidden{% endif %}{% for field in line %} {{ field.field.name }}{% endfor %} ">
+            <div class="form-row grp-row grp-cells-{{ line.fields|length }}{% if not line.fields|length == 1 %} grp-cells{% else %}{% if line.errors %} grp-errors{% endif %}{% endif %}{% if not line.has_visible_field %} grp-row-hidden{% endif %}{% for field in line %} {{ field.field.name }}{% endfor %} ">
                 {% for field in line %}
-                    {% if line.fields|length_is:"1" %}
+                    {% if line.fields|length == 1 %}
                         <div class="field-box l-2c-fluid l-d-4">
                     {% else %}
                         <div class="field-box grp-cell l-2c-fluid l-d-4 {{ field.field.name }}{% if field.field.errors %} grp-errors{% endif %}">
@@ -24,8 +24,8 @@
                                     {{ field.field }}
                                 {% endif %}
                         {% endif %}
-                            {% if line.fields|length_is:'1' %}{{ line.errors }}{% endif %}
-                            {% if not line.fields|length_is:'1' and not field.is_readonly %}{{ field.field.errors }}{% endif %}
+                            {% if line.fields|length == 1 %}{{ line.errors }}{% endif %}
+                            {% if not line.fields|length == 1 and not field.is_readonly %}{{ field.field.errors }}{% endif %}
                             {% if field.field.help_text %}
                                 <p class="grp-help">{{ field.field.help_text|safe }}</p>
                             {% endif %}

--- a/grappelli/templates/admin/includes/fieldset_inline.html
+++ b/grappelli/templates/admin/includes/fieldset_inline.html
@@ -4,9 +4,9 @@
         {% if fieldset.name %}<h4 class="grp-collapse-handler">{{ fieldset.name }}</h4>{% endif %}
         {% if fieldset.description %}<div class="grp-row"><p class="grp-description">{{ fieldset.description|safe }}</p></div>{% endif %}
         {% for line in fieldset %}
-            <div class="form-row grp-row grp-cells-{{ line.fields|length }}{% if not line.fields|length_is:"1" %} grp-cells{% else %}{% if line.errors %} grp-errors{% endif %}{% endif %}{% if not line.has_visible_field %} grp-row-hidden{% endif %}{% for field in line %} {{ field.field.name }}{% endfor %}">
+            <div class="form-row grp-row grp-cells-{{ line.fields|length }}{% if not line.fields|length == 1 %} grp-cells{% else %}{% if line.errors %} grp-errors{% endif %}{% endif %}{% if not line.has_visible_field %} grp-row-hidden{% endif %}{% for field in line %} {{ field.field.name }}{% endfor %}">
                 {% for field in line %}
-                    {% if line.fields|length_is:"1" %}
+                    {% if line.fields|length == 1 %}
                         <div class="field-box l-2c-fluid l-d-4">
                     {% else %}
                         <div class="field-box grp-cell l-2c-fluid l-d-4 {{ field.field.name }}{% if field.field.errors %} grp-errors{% endif %}">
@@ -24,8 +24,8 @@
                                     {{ field.field }}
                                 {% endif %}
                         {% endif %}
-                            {% if line.fields|length_is:'1' %}{{ line.errors }}{% endif %}
-                            {% if not line.fields|length_is:'1' and not field.is_readonly %}{{ field.field.errors }}{% endif %}
+                            {% if line.fields|length == 1 %}{{ line.errors }}{% endif %}
+                            {% if not line.fields|length == 1 and not field.is_readonly %}{{ field.field.errors }}{% endif %}
                             {% if field.field.help_text %}
                                 <p class="grp-help">{{ field.field.help_text|safe }}</p>
                             {% endif %}


### PR DESCRIPTION
From https://django.readthedocs.io/en/latest/releases/4.2.html
> The length_is template filter is deprecated in favor of [length](https://django.readthedocs.io/en/latest/ref/templates/builtins.html#std-templatefilter-length) and the == operator within an [{% if %}](https://django.readthedocs.io/en/latest/ref/templates/builtins.html#std-templatetag-if) tag

length_is will be removed in Django 5.1, see https://docs.djangoproject.com/en/dev/internals/deprecation/

I noticed this warning in a project using django-grappelli and figured I'd help get out ahead of the removal with a PR. Let me know if this need any additional testing or work!