### PR TITLE
Fix wrong translation in delete_confirmation.html

### DIFF
--- a/grappelli/templates/admin/delete_confirmation.html
+++ b/grappelli/templates/admin/delete_confirmation.html
@@ -52,8 +52,8 @@
                 <div class="grp-module grp-submit-row grp-fixed-footer">
                     <ul>
                         {% url opts|admin_urlname:'change' object.pk|admin_urlquote as object_url %}
-                        <li class="grp-float-left"><a href="{% add_preserved_filters object_url %}" class="grp-button grp-cancel-link">{% trans "Cancel" %}</a></li>
-                        <li><input type="submit" value="{% trans "Yes, I'm sure" %}" class="grp-button grp-default" /></li>
+                        <li class="grp-float-left"><a href="{% add_preserved_filters object_url %}" class="grp-button grp-cancel-link">{% trans "No, take me back" %}</a></li>
+                        <li><input type="submit" value="{% trans "Yes, I’m sure" %}" class="grp-button grp-default" /></li>
                     </ul>
                     <input type="hidden" name="post" value="yes" />
                     {% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1" />{% endif %}


### PR DESCRIPTION
Fix the translation strings used for the button. Otherwise, the translation won't work.
before:
![image](https://github.com/sehmaschine/django-grappelli/assets/1391925/f2948239-1a73-449d-9ac0-496370ea466b)
after:
![image](https://github.com/sehmaschine/django-grappelli/assets/1391925/1cc8c8fa-238d-41b3-8ae7-1e968477c6ef)

