### PR TITLE
Trigger change event in dismissRelatedLookupPopup

### DIFF
--- a/grappelli/static/admin/js/admin/RelatedObjectLookups.js
+++ b/grappelli/static/admin/js/admin/RelatedObjectLookups.js
@@ -52,6 +52,7 @@
         }
         // GRAPPELLI CUSTOM: element focus
         elem.focus();
+        $(elem).trigger('change');
         win.close();
     }
 


### PR DESCRIPTION
Fixes #1050 

I see that the change event gets triggered in most other cases, but not for this one.