### PR TITLE
Fix wrong translation string

### DIFF
--- a/grappelli/templates/admin/delete_selected_confirmation.html
+++ b/grappelli/templates/admin/delete_selected_confirmation.html
@@ -56,7 +56,7 @@
                     <input type="hidden" name="post" value="yes" />
                     <ul>
                         <li class="grp-float-left"><a href="." class="grp-button grp-cancel-link">{% trans "Cancel" %}</a></li>
-                        <li><input type="submit" value="{% trans "Yes, I'm sure" %}" class="grp-button grp-default" /></li>
+                        <li><input type="submit" value="{% trans "Yes, I’m sure" %}" class="grp-button grp-default" /></li>
                     </ul>
                     <input type="hidden" name="post" value="yes" />
                 </div>


### PR DESCRIPTION
same as in https://github.com/sehmaschine/django-grappelli/pull/1049,

while Django's own templates use this new apostrophe character: https://github.com/django/django/blob/main/django/contrib/admin/templates/admin/delete_selected_confirmation.html#L42

their actual translation characters are a mess with a mix and match between apostrophes and languages. The `en` language file however matches the templates:
https://github.com/django/django/blob/main/django/contrib/admin/locale/en/LC_MESSAGES/django.po#L609