### PR TITLE
fix: remove "font-weight: bold" style for `a` selector

### DIFF
--- a/grappelli/sass/partials/typography/_base.scss
+++ b/grappelli/sass/partials/typography/_base.scss
@@ -72,7 +72,6 @@ a {
     text-decoration: none;
     color: $grp-link-color;
     cursor: pointer;
-    font-weight: bold;
 
     &:hover {
         color: $grp-link-color-hover;


### PR DESCRIPTION
In commit 7478985, which was meant to remove the dependency on compass, a `font-weight: bold` style was added to all `a` elements. I have to imagine that this was added in error. It has caused a number of visual regressions in our django admin.